### PR TITLE
Document secret service settings

### DIFF
--- a/2.0/docs/services/configuration.md
+++ b/2.0/docs/services/configuration.md
@@ -54,6 +54,26 @@ For example, a `docroot` setting with `var: DOCROOT_SUBDIR` should use `build: t
 Changing a runtime-scoped setting marks the app service for redeploy. Changing a build-scoped setting marks it for
 rebuild.
 
+### Secret settings
+
+A service template can set `secret: true` on a setting that contains a password, token, credential-bearing URL, key,
+salt, or other sensitive value. Wodby encrypts a submitted secret setting and treats it as write-only: API responses
+report whether the value is configured but do not return the stored value. Entering a new value replaces the
+existing secret; clearing it removes the configured value.
+
+Secret settings cannot define `default`, because service templates are not secret storage. Stack templates likewise
+cannot embed an override value for a secret setting. Configure the value on the stack service or app service after the
+service has been imported.
+
+A setting that uses `from` must have the same secret classification as the matching setting on the linked service.
+The consuming setting keeps a link to the source setting rather than storing another copy of its value.
+
+Runtime secret settings require the primary workload container to use the list-based `helm.env` mapping. The
+map-style `helm.envKV` mapping places values directly in Helm values and therefore cannot be used for secret settings.
+
+Build-scoped secret settings use the CI secret-argument path and are redacted from API responses. The Dockerfile must
+still handle its matching `ARG` safely: copying a build argument into an image layer, file, or build log can expose it.
+
 ## Configs
 
 Services can define configs that represent configuration files or config payloads overridden at stack or app level.

--- a/2.0/docs/services/template.md
+++ b/2.0/docs/services/template.md
@@ -642,12 +642,35 @@ Each item supports:
 - `default`: optional default value.
 - `from`: optional link name to reuse the same setting from a linked service.
 - `required`: optional boolean.
+- `secret`: optional boolean. Defaults to `false`. Encrypts submitted values and makes the setting write-only.
 - `var`: required environment variable name created from this setting.
 - `runtime`: optional boolean. Defaults to `true`. When `false`, Wodby does not inject the setting-derived variable into runtime containers.
 - `build`: optional boolean. Defaults to `false`. When `true`, Wodby can pass the setting-derived variable to CI builds as a Docker build argument when the Dockerfile declares a matching `ARG`.
 
 At least one of `runtime` or `build` must be enabled. Use `build: true` for settings such as document root paths that
 must be available while building an image.
+
+A secret setting cannot define `default`, and a stack template cannot embed its override value. Configure the value
+after import. A setting inherited with `from` must have the same `secret` value as the matching setting on the linked
+service. Runtime secret settings require the primary container's list-based `helm.env` mapping; `helm.envKV` is not
+supported because it would place the decrypted value in Helm values.
+
+Example:
+
+```yaml
+settings:
+  - name: api_token
+    title: API token
+    description: Token used to authenticate outbound API requests
+    placeholder: Enter a token
+    var: API_TOKEN
+    required: true
+    secret: true
+```
+
+Wodby never returns the configured value for a secret setting. API responses retain an empty `value` for compatibility
+and expose `secret` and `hasValue` so clients can render a password control and configured state without revealing the
+credential.
 
 ### `imports`
 


### PR DESCRIPTION
## Summary

- document `secret: true` for service settings
- explain write-only configured-state behavior
- describe linked-setting compatibility and the `helm.env` runtime requirement
- document CI build-argument handling and Dockerfile exposure risks

## Validation

- `mkdocs build --strict`

## Coordination

This documents the backend secret-setting contract introduced by the companion backend change. No service manifest should adopt `secret: true` until the backend change is deployed.