### PR TITLE
Document service integration variable contracts

### DIFF
--- a/2.0/docs/integrations/variable.md
+++ b/2.0/docs/integrations/variable.md
@@ -74,6 +74,12 @@ the environment variable names yourself. The standard
 [environment-variable naming and reserved-name rules](../apps/environment-variables.md#names-and-reserved-variables)
 apply to custom mappings.
 
+Services can declare an exact variable contract instead of naming a particular provider. Wodby then accepts only
+integrations whose selected provider kind supplies the required names, secret classifications, and optionality. This is
+useful for reusable services that need credentials such as `BILLING_API_TOKEN` but should not depend on one globally
+defined provider. See the [`integrations[].variables` service template reference](../services/template.md#integrations)
+and [matching custom provider requirements](../providers/variable.md#matching-service-requirements).
+
 ## Related pages
 
 - [Integration types](types.md)

--- a/2.0/docs/providers/variable.md
+++ b/2.0/docs/providers/variable.md
@@ -53,6 +53,24 @@ apply to custom mappings.
 Variables exposed by variable providers are injected into runtime containers only. They are not passed to Docker image
 builds. Use build-scoped app-service environment variables or service settings for Dockerfile build arguments.
 
+### Matching service requirements
+
+A service can declare the exact environment variables it consumes under
+[`integrations[].variables`](../services/template.md#integrations). This lets the same service work with any built-in or
+custom variable provider whose selected kind exposes the required shape.
+
+For a custom provider to match:
+
+- every required variable name must be exposed by the same provider kind
+- a secret requirement must map to a secret provider field, and a non-secret requirement must map to a non-secret
+  field
+- a required service variable cannot map to an optional provider field
+- an optional service variable can map to either a required or optional provider field
+
+The provider can expose additional variables. They are not injected through a service integration that declares an
+explicit variable contract. The service does not need to name a specific provider, so each organization can create a
+provider with its own title and credentials while keeping the same environment-variable interface.
+
 ## Related pages
 
 - [Integrations overview](../integrations/index.md)

--- a/2.0/docs/services/template.md
+++ b/2.0/docs/services/template.md
@@ -612,15 +612,50 @@ Each item supports:
 - `required`: optional boolean.
 - `multiple`: optional boolean.
 - `labels`: optional labels used to filter compatible provider kinds.
+- `variables`: optional environment-variable contract for a variable integration.
 - `providers`: optional provider-specific overrides.
 
 An attached integration is compatible only when one of its selected provider kinds has the required `type` and every
-required label. Labels cannot be combined across different kinds, and an unselected kind does not make the integration
-compatible. When a service is imported, Wodby also verifies that at least one current public or organization provider
-kind can satisfy every declared integration requirement.
+required label and variable. Requirements cannot be combined across different kinds, and an unselected kind does not
+make the integration compatible. A provider may expose additional variables without affecting compatibility.
 
-For a variable integration, Wodby injects provider-wide fields plus fields belonging to the matching selected kinds.
-Fields belonging only to another selected kind are not exposed through that service integration slot.
+`variables` is supported only when `type` is `variable`. Each item supports:
+
+- `name`: required environment variable name.
+- `secret`: optional boolean. Defaults to `false`. It must exactly match whether the provider stores the field as a
+  secret.
+- `optional`: optional boolean. Defaults to `false`. A required service variable matches only a required provider
+  field; an optional service variable matches either a required or optional provider field.
+
+For example, this contract can be satisfied by a built-in or custom variable provider with matching fields:
+
+```yaml
+integrations:
+  - name: billing
+    title: Billing API
+    type: variable
+    required: true
+    variables:
+      - name: BILLING_API_URL
+      - name: BILLING_API_TOKEN
+        secret: true
+      - name: BILLING_ACCOUNT_ID
+        optional: true
+```
+
+A variable contract without `labels` does not require a matching provider to exist in the service owner's organization
+when the service is imported. This allows a reusable service to declare its interface while each consuming organization
+creates its own [custom variable provider](../providers/variable.md#custom-variable-providers). If the requirement also
+uses `labels`, Wodby verifies during import that a current public or organization provider kind satisfies the complete
+contract.
+
+When `variables` is present, Wodby injects only the variables declared by the service. Deployment fails if a required
+value is missing, resolves more than once, or is not stored with the declared secret classification. Without
+`variables`, the existing behavior remains: Wodby injects provider-wide fields plus fields belonging to the matching
+selected kinds. Fields belonging only to another selected kind are not exposed through that service integration slot.
+
+Do not combine `variables` with `providers`. A native variable contract consumes provider environment variables by
+their declared names, while `providers` defines provider-specific projections to different environment variables.
 
 Each `integrations[].providers[]` item supports:
 


### PR DESCRIPTION
## Summary

- document the new `integrations[].variables` service-manifest contract
- explain exact variable name, secret classification, and optionality matching
- show how reusable services can match built-in or custom variable providers
- clarify runtime export behavior and the restriction against mixing native contracts with provider-specific projections

## Why

Services currently have to model unsupported third-party dependencies as settings or provider-specific projections. A provider-independent environment-variable contract lets those dependencies remain reusable integrations.

## User impact

Service authors can publish the variables their application consumes without depending on a particular provider name. Organizations can satisfy that contract with their own custom variable provider while Wodby validates compatibility.

## Validation

- `mkdocs build -d /tmp/wodby-docs-service-integration-variables-site`
- verified generated cross-page anchors for the service template, variable provider, and variable integration pages