### PR TITLE
Document custom provider revisions and catalog actions

### DIFF
--- a/2.0/docs/providers/custom-variable-providers.md
+++ b/2.0/docs/providers/custom-variable-providers.md
@@ -12,8 +12,8 @@ permission audits, or infrastructure resources.
 | Method | Use when |
 | --- | --- |
 | New variable provider | You want to define a small set of environment variables in the dashboard. |
-| From manifest | You have a local `provider.yml` and do not need Wodby to track a Git repository. |
-| Import from Git | You want Git to remain the source of truth, use automatic updates, or keep several providers in one repository. |
+| New from manifest | You have a local `provider.yml` and do not need Wodby to track a Git repository. |
+| Import from git | You want Git to remain the source of truth, use automatic updates, or keep several providers in one repository. |
 
 All three methods let you select organization or project ownership. An organization-owned provider can be shared with
 projects in the same organization from its `Sharing` tab.
@@ -37,13 +37,13 @@ Use quick create when you do not need to write a manifest first:
 4. Add the fields and environment-variable names that integrations should expose.
 5. Create the provider.
 
-Open the created provider to review its generated manifest. Later updates use the same versioned manifest workflow as
-providers created from a local manifest.
+Open the created provider to review its generated manifest. Later updates use the same revision workflow as providers
+created from a local manifest.
 
 ## Create from a manifest
 
 1. Open `Providers`.
-2. Select `From manifest`.
+2. Select `New from manifest`.
 3. Select the organization or project that should own the provider.
 4. Paste the YAML manifest, or read it from a local `.yml` or `.yaml` file.
 5. Create the provider.
@@ -54,7 +54,6 @@ A minimal manifest looks like this:
 name: acme-api
 title: Acme API
 icon: variable
-version: 1.0.0
 
 kinds:
   - name: credentials
@@ -84,7 +83,6 @@ The top-level manifest supports:
 | `name` | Yes | Local machine-name slug using lowercase letters, numbers, and hyphens. |
 | `title` | Yes | Display name shown in the dashboard. |
 | `icon` | Yes | Provider icon identifier. Use `variable` for the generic variable-provider icon. |
-| `version` | Yes | Strict semantic version in `major.minor.patch` form, such as `1.2.0`. |
 | `instructions` | No | Setup guidance shown when users configure an integration. |
 | `fields` | No | Fields shared by every kind in the provider. |
 | `kinds` | Yes | One or more variable integration kinds. |
@@ -110,7 +108,11 @@ apply. Each manifest is limited to 1 MiB.
 Unknown manifest properties, duplicate YAML keys, and YAML aliases are rejected. This keeps the stored manifest
 unambiguous and prevents unsupported provider capabilities from being enabled accidentally.
 
-## Import from Git
+Custom provider manifests do not use a top-level `version`; Wodby records their history with provider revision
+numbers. Legacy custom manifests that still contain a semantic `version` remain importable during the transition, but
+Wodby ignores and removes that field from the stored manifest.
+
+## Import from git
 
 Connect a [Git provider integration](git.md) before importing a provider from a repository.
 
@@ -140,7 +142,7 @@ outside the repository.
 To import:
 
 1. Open `Providers`.
-2. Select `Import from Git`.
+2. Select `Import from git`.
 3. Select the owner, Git integration, repository, ref type, and branch or tag.
 4. Configure automatic update settings if required.
 5. Select `Import` and review the task log.
@@ -150,8 +152,9 @@ skipped and reported in the import task.
 
 ## Update a provider
 
-Provider updates create a new revision. Open the provider's `Manifest` tab to see the current source and version, and
-use `Tasks` to review import and update logs.
+Provider content changes create a new revision. Open the provider's `Manifest` tab to see the current source and
+revision number, and use `Tasks` to review import and update logs. Reapplying identical manifest content does not create
+a duplicate revision.
 
 ### Update from a local manifest
 
@@ -168,11 +171,9 @@ tracked ref can update all resources using that repository together. When changi
 all shared usages so they remain aligned. The tracked ref and Git auto-update settings belong to the repository
 connection, so changing them from one resource also changes them for the other resources that share it.
 
-### Version and compatibility rules
+### Revision and compatibility rules
 
 - Keep the manifest `name` unchanged.
-- Increase `version` whenever the manifest content changes.
-- Versions cannot move backwards, and changed content cannot reuse the current version.
 - If integrations already use the provider, an update must preserve the credential contract: kind names and options,
   field names and types, environment-variable mappings, validation, optionality, and upload constraints.
 - Metadata-only changes, such as titles, instructions, and icons, can update existing integrations to the new provider
@@ -186,12 +187,13 @@ integrations deliberately.
 Git-backed providers can update when a supported Git integration receives a matching push event:
 
 - a tracked branch updates when that same branch receives a push
-- a tracked semantic-version tag can follow newer tags, limited to patch, minor, or major changes
+- a tracked semantic-version Git tag can follow newer tags, limited to patch, minor, or major changes
 - commit-pinned sources cannot use automatic updates
 
-Configure this under `Operations > Git auto update settings`. Automatic updates use the same manifest validation,
-version, and compatibility rules as manual updates. A rejected update leaves the current provider revision active; open
-the provider's `Tasks` tab to review the error.
+Configure this under `Operations > Git auto update settings`. Tag matching applies to Git refs and is independent of
+the provider manifest revision. Automatic updates use the same manifest validation and compatibility rules as manual
+updates. A rejected update leaves the current provider revision active; open the provider's `Tasks` tab to review the
+error.
 
 ## Sharing and deletion
 

--- a/2.0/docs/providers/custom-variable-providers.md
+++ b/2.0/docs/providers/custom-variable-providers.md
@@ -11,7 +11,7 @@ permission audits, or infrastructure resources.
 
 | Method | Use when |
 | --- | --- |
-| Quick create | You want to define a small set of environment variables in the dashboard. |
+| New variable provider | You want to define a small set of environment variables in the dashboard. |
 | From manifest | You have a local `provider.yml` and do not need Wodby to track a Git repository. |
 | Import from Git | You want Git to remain the source of truth, use automatic updates, or keep several providers in one repository. |
 
@@ -27,12 +27,12 @@ without colliding.
 Use the full namespaced name when a workflow asks for the provider machine name. The manifest itself keeps the local
 slug. Existing custom providers also appear under their organization namespace.
 
-## Quick create
+## Create a variable provider in the dashboard
 
 Use quick create when you do not need to write a manifest first:
 
 1. Open `Providers`.
-2. Select `Quick create`.
+2. Select `New variable provider`.
 3. Select the owner and enter the provider name and title.
 4. Add the fields and environment-variable names that integrations should expose.
 5. Create the provider.

--- a/2.0/docs/providers/variable.md
+++ b/2.0/docs/providers/variable.md
@@ -46,8 +46,8 @@ Variable provider integrations are typically attached to:
 ## Custom variable providers
 
 If a built-in provider is missing, you can create your own variable provider in the dashboard. Use
-`New variable provider` for a small provider, `From manifest` for a local `provider.yml`, or `Import from Git` to track
-one or several versioned providers in a repository.
+`New variable provider` for a small provider, `New from manifest` for a local `provider.yml`, or `Import from git` to
+track one or several provider manifests in a repository.
 
 Custom provider names are scoped to the organization, so their full machine name uses
 `<organization>/<provider-name>`. Git-backed providers support manual updates and configurable branch or semantic-tag

--- a/2.0/docs/providers/variable.md
+++ b/2.0/docs/providers/variable.md
@@ -45,9 +45,9 @@ Variable provider integrations are typically attached to:
 
 ## Custom variable providers
 
-If a built-in provider is missing, you can create your own variable provider in the dashboard. Use `Quick create` for
-a small provider, `From manifest` for a local `provider.yml`, or `Import from Git` to track one or several versioned
-providers in a repository.
+If a built-in provider is missing, you can create your own variable provider in the dashboard. Use
+`New variable provider` for a small provider, `From manifest` for a local `provider.yml`, or `Import from Git` to track
+one or several versioned providers in a repository.
 
 Custom provider names are scoped to the organization, so their full machine name uses
 `<organization>/<provider-name>`. Git-backed providers support manual updates and configurable branch or semantic-tag

--- a/2.0/docs/services/create.md
+++ b/2.0/docs/services/create.md
@@ -71,7 +71,7 @@ Each listed directory must contain its own `service.yml`. See the [service templ
 1. Connect a Git provider integration if the repository is not already available. See [Git provider](../providers/git.md).
    If the service uses private container images, also create a registry integration for the image registry.
 2. Open `Services`.
-3. Select `New service from Git`.
+3. Select `Import from git`.
 4. Select the organization or project, Git integration, repository, ref type, and ref. For private images, select the
    optional `Registry integration` that matches the image registry host.
 5. Create the service.

--- a/2.0/docs/stacks/create.md
+++ b/2.0/docs/stacks/create.md
@@ -88,7 +88,7 @@ Each listed directory must contain its own `stack.yml`. See the [stack template 
 
 1. Connect a Git provider integration if the repository is not already available. See [Git provider](../providers/git.md).
 2. Open `Stacks`.
-3. Select `New stack from Git`.
+3. Select `Import from git`.
 4. Select the organization or project, Git integration, repository, ref type, and ref.
 5. Create the stack.
 
@@ -130,7 +130,7 @@ Use manifest creation when you have a `stack.yml` file and do not need Wodby to 
 ### Dashboard
 
 1. Open `Stacks`.
-2. Select `New stack from manifest`.
+2. Select `New from manifest`.
 3. Select the organization or project that should own the stack.
 4. Paste the manifest YAML, or read it from a local `stack.yml` file.
 5. Enter the stack version.


### PR DESCRIPTION
## Summary
- document revision-based custom provider history and remove the manifest version requirement
- explain transitional handling of legacy version fields and the difference between Git tag semver and provider revisions
- update provider, stack, and service instructions to match the current dashboard action labels
- keep the public guide free of internal repository references

## Validation
- mkdocs build --strict
- audited the diff for internal paths and private repository references