### PR TITLE
Document supported SSH key types

### DIFF
--- a/1.0/docs/infrastructure/containers.md
+++ b/1.0/docs/infrastructure/containers.md
@@ -6,7 +6,15 @@ Most of the container images provided in our managed stacks are based on the lig
 
 ### via SSH container
 
-Some stacks provide an SSHd container to access your codebase, you can find the SSH command on `Instance > Stack > SSHd` page. We'll automatically add your public SSH keys to this container. You can add your public keys from `Profile > Keys > Add new key` page. 
+Some stacks provide an SSHd container to access your codebase. You can find the SSH command on the `Instance > Stack > SSHd` page. We automatically add the public SSH keys from your Wodby profile to this container for every user who has access to the instance. Add a key from `Profile > Keys > Add new key`.
+
+Wodby supports the following OpenSSH public key types:
+
+* Ed25519 (`ssh-ed25519`) — recommended
+* ECDSA with the NIST P-256, P-384, or P-521 curves (`ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384`, or `ecdsa-sha2-nistp521`)
+* RSA (`ssh-rsa`) with a minimum key size of 2048 bits
+
+Paste one public key in OpenSSH format. An optional comment after the key is accepted. Authorized-keys options, DSA keys, hardware-backed FIDO/security-key (`sk-*`) keys, OpenSSH certificates, and post-quantum key types are not supported.
 
 ### as default user
 

--- a/1.0/includes/containers/php-sshd.md
+++ b/1.0/includes/containers/php-sshd.md
@@ -1,3 +1,11 @@
-A duplicate of PHP container runs with SSH daemon (instead of FPM). You can find access information on `[Instance] > Stack > SSH`
+A duplicate of the PHP container runs an SSH daemon instead of FPM. You can find access information on `[Instance] > Stack > SSH`.
 
-Public SSH keys from your Wodby profile will be added automatically for all users that have access to an instance. 
+Public SSH keys from your Wodby profile are added automatically for every user who has access to the instance.
+
+Wodby supports the following OpenSSH public key types:
+
+* Ed25519 (`ssh-ed25519`) — recommended
+* ECDSA with the NIST P-256, P-384, or P-521 curves (`ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384`, or `ecdsa-sha2-nistp521`)
+* RSA (`ssh-rsa`) with a minimum key size of 2048 bits
+
+Paste one public key in OpenSSH format. An optional comment after the key is accepted. Authorized-keys options, DSA keys, hardware-backed FIDO/security-key (`sk-*`) keys, OpenSSH certificates, and post-quantum key types are not supported.


### PR DESCRIPTION
## What changed

- document Ed25519 as the recommended Wodby 1 user SSH key type
- list supported ECDSA curves and the 2048-bit minimum for RSA keys
- identify unsupported authorized-keys options, DSA, FIDO/security-key, certificate, and post-quantum formats
- publish the guidance on both the infrastructure page and shared stack SSH-container pages

## Why

Wodby 1 is expanding profile SSH-key validation beyond the legacy key formats. Users need an exact public contract for which OpenSSH public keys they can add and which formats remain unsupported.

## Impact

Documentation only. This PR should be merged and published with or after wodby/backend-old#374.

## Checks

- `mkdocs build -d /tmp/wodby-docs-modern-ssh-keys-a944-site` from `1.0/`
- `git diff --check`
- verified the generated infrastructure and Drupal stack pages contain the key-type guidance