### PR TITLE
Document organization 2FA enforcement

### DIFF
--- a/1.0/docs/account-security.md
+++ b/1.0/docs/account-security.md
@@ -1,9 +1,10 @@
 # Account security
 
-Wodby 1 supports optional two-factor authentication (2FA) for individual user
-accounts. When 2FA is enabled, signing in requires both your password and a
-time-based code from a compatible TOTP authenticator app. Organization roles
-and memberships do not affect this setting.
+Wodby 1 supports two-factor authentication (2FA) for individual user accounts.
+When 2FA is enabled, signing in requires both your password and a time-based
+code from a compatible TOTP authenticator app. You can enable it voluntarily,
+and an organization owner or administrator can require it for every active
+member of an organization.
 
 ## Enable two-factor authentication
 
@@ -56,11 +57,49 @@ To replace your recovery codes:
 
 Generating new codes immediately invalidates every previous recovery code.
 
+## Require 2FA for an organization
+
+Organization owners and administrators can require every active member to use
+account-level 2FA:
+
+1. Enable 2FA for your own account under **Account > Security**.
+2. Open **Organization > Settings > Security**.
+3. Select **Require two-factor authentication**.
+4. Enter your current password and an authenticator or recovery code.
+5. Select **Save security policy**.
+
+The policy takes effect immediately. It does not remove members, invalidate
+their passwords, or end their authenticated session. An active member who has
+not enabled 2FA is kept on **Account > Security** after signing in and cannot
+continue into the organization until setup is complete. Access is restored as
+soon as the member verifies and enables 2FA.
+
+Invited users are not active members until they accept their invitation. After
+acceptance, the same requirement applies before they can use the organization.
+
+Owners and administrators can open **Organization > Settings > Team** to see
+the 2FA status of each member:
+
+- **Enabled** means the member has account-level 2FA enabled.
+- **Not enabled** means the active member must finish setup when enforcement is
+  enabled.
+- **Not registered** identifies an invitation that has not been accepted yet.
+
+The status is not shown to lower-privileged roles.
+
+To stop enforcing the policy, clear **Require two-factor authentication** and
+confirm the change with your password and a second factor. This does not turn
+off 2FA for members who already enabled it.
+
 ## Disable two-factor authentication
 
 Open **Account > Security**, select **Disable two-factor authentication**, and
 enter your current password plus either an authenticator code or an unused
 recovery code. Future logins will require only your password.
+
+You cannot disable account-level 2FA while you are an active member of any
+organization that requires it. An organization owner or administrator must
+first disable that policy or remove your active membership.
 
 ## Lost authenticator access
 

--- a/1.0/docs/account-security.md
+++ b/1.0/docs/account-security.md
@@ -3,8 +3,8 @@
 Wodby 1 supports two-factor authentication (2FA) for individual user accounts.
 When 2FA is enabled, signing in requires both your password and a time-based
 code from a compatible TOTP authenticator app. You can enable it voluntarily,
-and an organization owner or administrator can require it for every active
-member of an organization.
+and an organization owner can require it for every active member of an
+organization.
 
 ## Enable two-factor authentication
 
@@ -59,8 +59,7 @@ Generating new codes immediately invalidates every previous recovery code.
 
 ## Require 2FA for an organization
 
-Organization owners and administrators can require every active member to use
-account-level 2FA:
+Organization owners can require every active member to use account-level 2FA:
 
 1. Enable 2FA for your own account under **Account > Security**.
 2. Open **Organization > Settings > Security**.
@@ -98,8 +97,8 @@ enter your current password plus either an authenticator code or an unused
 recovery code. Future logins will require only your password.
 
 You cannot disable account-level 2FA while you are an active member of any
-organization that requires it. An organization owner or administrator must
-first disable that policy or remove your active membership.
+organization that requires it. An organization owner must first disable that
+policy or remove your active membership.
 
 ## Lost authenticator access
 

--- a/1.0/docs/roles.md
+++ b/1.0/docs/roles.md
@@ -19,7 +19,7 @@ Wodby provides a set of default roles with following permissions:
 | Delete apps            | ✓     | ✓             |             |           |              |
 | Manage team            | ✓     | ✓             |             |           |              |
 | Manage organization    | ✓     | ✓             |             |           |              |
-| Manage organization 2FA policy | ✓ | ✓           |             |           |              |
+| Manage organization 2FA policy | ✓ |             |             |           |              |
 | View member 2FA status | ✓     | ✓             |             |           |              |
 | Delete stage instance  | ✓     | ✓             |             |           |              |
 | Delete prod instance   | ✓     | ✓             |             |           |              |

--- a/1.0/docs/roles.md
+++ b/1.0/docs/roles.md
@@ -19,6 +19,8 @@ Wodby provides a set of default roles with following permissions:
 | Delete apps            | ✓     | ✓             |             |           |              |
 | Manage team            | ✓     | ✓             |             |           |              |
 | Manage organization    | ✓     | ✓             |             |           |              |
+| Manage organization 2FA policy | ✓ | ✓           |             |           |              |
+| View member 2FA status | ✓     | ✓             |             |           |              |
 | Delete stage instance  | ✓     | ✓             |             |           |              |
 | Delete prod instance   | ✓     | ✓             |             |           |              |
 


### PR DESCRIPTION
## Summary

- explain how Wodby 1 organization owners enable or disable required 2FA
- document the restricted member setup flow without implying membership or account removal
- describe the admin-only Team page compliance statuses
- clarify that account-level 2FA cannot be disabled while an active organization requires it
- update the public role matrix for owner-only policy management and admin status visibility

## Related implementation

- wodby/backend-old#376
- wodby/dashboard-old#134

## Validation

- Wodby 1 MkDocs build completed successfully with the repository Docker image
- final Markdown diff and whitespace checks pass