### PR TITLE
Document linked third-party CI source refs

### DIFF
--- a/2.0/docs/apps/builds.md
+++ b/2.0/docs/apps/builds.md
@@ -26,7 +26,10 @@ to make the relationship explicit.
 
 When a connected source inherits third-party CI, linking its Git repository in Wodby is optional.
 `wodby ci init $WODBY_APP_SERVICE_ID` creates the build from the app service ID and the git metadata detected in the CI
-workspace. Boilerplate sources instead require the repository and pipeline used by Wodby CI.
+workspace. If you link a repository, you must select a branch, tag, or commit, and the reported build source must match
+that selection. Leave it unlinked when the external pipeline should control source selection. Boilerplate sources
+instead require the repository and pipeline used by Wodby CI. See
+[third-party CI source selection](../cicd/third-party.md#source-selection).
 
 An app instance can include source owners using both CI paths. Wodby coordinates them in one build and deployment
 operation, but does not deploy until every source owner has supplied a deployable build.

--- a/2.0/docs/apps/deploys.md
+++ b/2.0/docs/apps/deploys.md
@@ -109,9 +109,9 @@ In that flow you can:
 - choose from available successful builds for services with build sources, including eligible older builds
 - choose **New build** only when the app service's CI provider and build source support dashboard-triggered builds
 
-If **New build** is unavailable, the build selector explains whether the service needs a linked repository, a GitLab
-branch or tag, a previously recorded GitHub Actions or CircleCI workflow, or whether it uses external-only Custom CI.
-A compatible previous successful build remains selectable even when the dashboard cannot start a new one.
+If **New build** is unavailable, the build selector explains whether the service needs a linked repository and ref, a
+previously recorded GitHub Actions or CircleCI workflow from the selected ref, or whether it uses external-only Custom
+CI. A compatible previous successful build remains selectable even when the dashboard cannot start a new one.
 
 If you deploy only a subset of services, Wodby applies that ordering only inside the selected set. Repository
 post-deployment scripts run only when the app service that owns the corresponding build is included in the selected

--- a/2.0/docs/cicd/git.md
+++ b/2.0/docs/cicd/git.md
@@ -3,8 +3,9 @@
 Start by creating a Git integration from a supported Git provider such as [GitHub](../providers/github.md),
 [GitLab](../providers/gitlab.md), or [Bitbucket](../providers/bitbucket.md). A connected build source inherits the app
 instance's Default CI. Under Wodby CI, its selected repository and ref are required. Under third-party CI, linking the
-repository in Wodby is optional because the CI provider performs the checkout. Public and cloned boilerplate sources
-use Wodby CI regardless of Default CI.
+repository in Wodby is optional because the CI provider performs the checkout. If you link it, you must select a branch,
+tag, or commit; Wodby accepts only CI builds that match that source. Leave it unlinked when source selection should
+remain entirely in the external pipeline. Public and cloned boilerplate sources use Wodby CI regardless of Default CI.
 
 ## Repository authentication
 
@@ -27,6 +28,8 @@ If you use [third-party CI](third-party.md), keep the provider-native config in 
 
 In Wodby CI, the `clone` step checks out the repository configured as the build source. In third-party CI, the CI provider performs the checkout and Wodby CLI works from that existing workspace.
 
-You can change the repository and the selected branch or tag for an existing app instance from the Build Source section of the app service when a repository is linked.
+You can change the repository and the selected branch, tag, or commit for an existing app instance from the Build
+Source section of the app service when a repository is linked. See [third-party CI source selection](third-party.md#source-selection)
+for how these changes affect CI build admission and deployment.
 
 For example configurations, see the [`wodby/wodby-ci`](https://github.com/wodby/wodby-ci/tree/2.0) repository.

--- a/2.0/docs/cicd/index.md
+++ b/2.0/docs/cicd/index.md
@@ -31,7 +31,9 @@ If no external default is configured, new instances use [Wodby CI](wodby-ci.md) 
 
 For connected sources that inherit third-party CI, an app service does not have to link a Git repository in Wodby. The
 CI provider supplies the checkout, and Wodby CLI sends commit, ref, and build metadata when it creates the app build.
-Public and cloned boilerplate sources require their Wodby CI pipeline and Git source.
+If you link a repository, select a branch, tag, or commit; Wodby registers only builds that match the linked source.
+Leave it unlinked when source selection belongs entirely to the external pipeline. Public and cloned boilerplate
+sources require their Wodby CI pipeline and Git source. See [third-party CI source selection](third-party.md#source-selection).
 
 When a build or deployment includes services using both CI paths, Wodby starts the Wodby CI builds and the supported
 third-party builds as one operation. Deployment waits until every service that owns a build source has provided a

--- a/2.0/docs/cicd/third-party.md
+++ b/2.0/docs/cicd/third-party.md
@@ -22,10 +22,24 @@ provider is not supported directly. With Custom CI, Wodby accepts the provider v
 
 You can find the app service ID on the Overview page of the corresponding app service.
 
+## Source selection
+
 When a connected build source inherits third-party Default CI, it does not have to link a Git repository in Wodby. The
 CI provider checks out the code, and Wodby CLI creates the app build from the app service ID plus the git metadata it
-detects in the CI workspace. You can still link a Git repository when you want Wodby to show repository metadata or
-start supported provider builds from the dashboard.
+detects in the CI workspace. In this mode, source selection belongs entirely to the external pipeline.
+
+If you link a Git repository, you must also select a branch, tag, or commit. Wodby then accepts only CI builds that
+match that repository and selected source:
+
+- a branch or tag must match both the reported ref type and exact ref name
+- a commit source must match the reported commit SHA
+
+For example, if the linked source selects the `main` branch, a pull request workflow that checks out and reports a
+feature branch cannot create a Wodby build for that service. Leave the repository unlinked only when the external
+pipeline should control which refs can build and deploy.
+
+Changing a linked repository or ref takes effect immediately. A build initialized for the previous source cannot later
+be deployed with `wodby ci deploy`; start a new workflow from the currently selected source instead.
 
 Public and cloned boilerplate sources use Wodby CI even when the instance's Default CI is third-party. They are not
 initialized with `WODBY_APP_SERVICE_ID`. An app may contain both kinds of source; its deployment waits for builds from
@@ -36,11 +50,12 @@ all source owners before it starts.
 Dashboard build support is provider-specific:
 
 - **GitHub Actions** starts a fresh `workflow_dispatch` using a previously recorded workflow for the linked repository
-  and app service. Run the first workflow outside Wodby so its workflow ID and ref can be recorded.
+  and app service, and dispatches it against the selected ref. Run the first workflow on that ref outside Wodby so its
+  workflow ID can be recorded. Workflows recorded from other refs are not used.
 - **GitLab CI** creates a fresh pipeline for the linked repository and configured branch or tag. A previous build is not
   required.
-- **CircleCI** reruns a previously recorded workflow for the linked repository and app service. Run the first workflow
-  outside Wodby so it can be recorded.
+- **CircleCI** reruns a previously recorded workflow for the linked repository, selected ref, and app service. Run the
+  first workflow on that ref outside Wodby so it can be recorded.
 - **Custom CI** cannot be started or rerun from the dashboard. Start it in the external CI system.
 
 When these requirements are not met, Wodby disables **New build** and shows the missing repository, ref, previously

--- a/2.0/docs/providers/circleci.md
+++ b/2.0/docs/providers/circleci.md
@@ -3,8 +3,8 @@
 ## New build
 
 Wodby starts a CircleCI build from the dashboard by rerunning a previously recorded workflow. Link the app service's
-Git repository and run the first CircleCI workflow outside Wodby so the workflow can be recorded. If the recorded
-workflow is no longer rerunnable in CircleCI, start it again from CircleCI.
+Git repository, select a branch or tag, and run the first CircleCI workflow on that ref outside Wodby so the workflow
+can be recorded. If the recorded workflow is no longer rerunnable in CircleCI, start it again from CircleCI.
 
 ## Build examples with Wodby CLI 2.0
 

--- a/2.0/docs/providers/github.md
+++ b/2.0/docs/providers/github.md
@@ -33,9 +33,9 @@ boilerplate code but own the resulting repository.
 
 Wodby supports GitHub Actions as a third-party CI integration.
 
-- Link the app service to the GitHub repository and run the first workflow outside Wodby so its workflow ID and ref can
-  be recorded
-- After a workflow has been recorded, you can trigger a fresh workflow run from Wodby
+- Link the app service to the GitHub repository, select a branch or tag, and run the first workflow on that ref outside
+  Wodby so its workflow ID can be recorded
+- After a matching workflow has been recorded, you can trigger a fresh workflow run from Wodby on the selected ref
 - You can also re-run the workflow run associated with the last recorded build
 - The GitHub App installation must have access to the repository with Actions permissions enabled
 - Starting a new workflow run requires the workflow to support `workflow_dispatch`


### PR DESCRIPTION
## Summary

- explain the two supported third-party CI source modes: repository-less external selection and linked repository selection
- document that linked repositories require a branch, tag, or commit and that reported CI metadata must match it
- clarify what happens when the linked source changes after a build is initialized
- update GitHub Actions and CircleCI dashboard-launch guidance to require workflow history from the selected ref

## User impact

Users can now distinguish when source policy belongs entirely to their external pipeline and when Wodby enforces a linked repository and ref. The guide also explains why an unrelated pull request workflow is rejected when the app service selects another branch.

## Validation

- strict MkDocs build for the Wodby 2.0 configuration
- reviewed all changed public files, commit metadata, and PR text for private or internal references

## Rollout

Publish this documentation alongside the product rollout that requires refs for linked third-party CI build sources.