### PR TITLE
Document legacy linked CI source compatibility

### DIFF
--- a/2.0/docs/apps/builds.md
+++ b/2.0/docs/apps/builds.md
@@ -26,9 +26,9 @@ to make the relationship explicit.
 
 When a connected source inherits third-party CI, linking its Git repository in Wodby is optional.
 `wodby ci init $WODBY_APP_SERVICE_ID` creates the build from the app service ID and the git metadata detected in the CI
-workspace. If you link a repository, you must select a branch, tag, or commit, and the reported build source must match
-that selection. Leave it unlinked when the external pipeline should control source selection. Boilerplate sources
-instead require the repository and pipeline used by Wodby CI. See
+workspace. When you link or edit a repository, you must select a branch, tag, or commit, and the reported build source
+must match that selection. Leave it unlinked when the external pipeline should control source selection. Boilerplate
+sources instead require the repository and pipeline used by Wodby CI. See
 [third-party CI source selection](../cicd/third-party.md#source-selection).
 
 An app instance can include source owners using both CI paths. Wodby coordinates them in one build and deployment

--- a/2.0/docs/cicd/git.md
+++ b/2.0/docs/cicd/git.md
@@ -3,9 +3,10 @@
 Start by creating a Git integration from a supported Git provider such as [GitHub](../providers/github.md),
 [GitLab](../providers/gitlab.md), or [Bitbucket](../providers/bitbucket.md). A connected build source inherits the app
 instance's Default CI. Under Wodby CI, its selected repository and ref are required. Under third-party CI, linking the
-repository in Wodby is optional because the CI provider performs the checkout. If you link it, you must select a branch,
-tag, or commit; Wodby accepts only CI builds that match that source. Leave it unlinked when source selection should
-remain entirely in the external pipeline. Public and cloned boilerplate sources use Wodby CI regardless of Default CI.
+repository in Wodby is optional because the CI provider performs the checkout. When you link or edit it, you must select
+a branch, tag, or commit; Wodby accepts only CI builds that match that source. Leave it unlinked when source selection
+should remain entirely in the external pipeline. Public and cloned boilerplate sources use Wodby CI regardless of
+Default CI.
 
 ## Repository authentication
 

--- a/2.0/docs/cicd/index.md
+++ b/2.0/docs/cicd/index.md
@@ -31,9 +31,10 @@ If no external default is configured, new instances use [Wodby CI](wodby-ci.md) 
 
 For connected sources that inherit third-party CI, an app service does not have to link a Git repository in Wodby. The
 CI provider supplies the checkout, and Wodby CLI sends commit, ref, and build metadata when it creates the app build.
-If you link a repository, select a branch, tag, or commit; Wodby registers only builds that match the linked source.
-Leave it unlinked when source selection belongs entirely to the external pipeline. Public and cloned boilerplate
-sources require their Wodby CI pipeline and Git source. See [third-party CI source selection](third-party.md#source-selection).
+When you link or edit a repository, select a branch, tag, or commit; Wodby registers only builds that match the linked
+source. Leave it unlinked when source selection belongs entirely to the external pipeline. Public and cloned
+boilerplate sources require their Wodby CI pipeline and Git source. See
+[third-party CI source selection](third-party.md#source-selection).
 
 When a build or deployment includes services using both CI paths, Wodby starts the Wodby CI builds and the supported
 third-party builds as one operation. Deployment waits until every service that owns a build source has provided a

--- a/2.0/docs/cicd/third-party.md
+++ b/2.0/docs/cicd/third-party.md
@@ -28,8 +28,8 @@ When a connected build source inherits third-party Default CI, it does not have 
 CI provider checks out the code, and Wodby CLI creates the app build from the app service ID plus the git metadata it
 detects in the CI workspace. In this mode, source selection belongs entirely to the external pipeline.
 
-If you link a Git repository, you must also select a branch, tag, or commit. Wodby then accepts only CI builds that
-match that repository and selected source:
+When you link a Git repository or edit an existing linked source, you must also select a branch, tag, or commit. Wodby
+then accepts only CI builds that match that repository and selected source:
 
 - a branch or tag must match both the reported ref type and exact ref name
 - a commit source must match the reported commit SHA
@@ -40,6 +40,10 @@ pipeline should control which refs can build and deploy.
 
 Changing a linked repository or ref takes effect immediately. A build initialized for the previous source cannot later
 be deployed with `wodby ci deploy`; start a new workflow from the currently selected source instead.
+
+Existing linked sources saved before ref selection was required may have no selected ref. They continue accepting CI
+builds from the linked repository regardless of branch or tag until you edit the source. Dashboard-triggered builds
+remain unavailable for these sources; select a ref to enable matching and supported dashboard build actions.
 
 Public and cloned boilerplate sources use Wodby CI even when the instance's Default CI is third-party. They are not
 initialized with `WODBY_APP_SERVICE_ID`. An app may contain both kinds of source; its deployment waits for builds from


### PR DESCRIPTION
## Summary

- clarify that ref selection is required when creating or editing a linked third-party CI source
- document the compatibility behavior for existing linked sources saved without a ref
- explain that legacy empty-ref sources remain repository-scoped but cannot start dashboard-triggered builds until a ref is selected

## User impact

Existing apps can continue running external CI from their linked repository without an immediate configuration change. Selecting a ref upgrades the source to exact branch, tag, or commit matching.

## Validation

- strict MkDocs build for the Wodby 2.0 configuration
- reviewed changed public files, commit metadata, and PR text for private or internal references