### PR TITLE
Document deployment build grouping behavior

### DIFF
--- a/2.0/docs/apps/builds.md
+++ b/2.0/docs/apps/builds.md
@@ -31,8 +31,17 @@ must match that selection. Leave it unlinked when the external pipeline should c
 sources instead require the repository and pipeline used by Wodby CI. See
 [third-party CI source selection](../cicd/third-party.md#source-selection).
 
-An app instance can include source owners using both CI paths. Wodby coordinates them in one build and deployment
-operation, but does not deploy until every source owner has supplied a deployable build.
+An app instance can include source owners using both CI paths. Each build operation records the exact source owners it
+starts or expects. The resulting deployment waits for those owners only; another buildable service in the same app
+does not block the deployment unless it was selected for that operation.
+
+Selecting **New build** for multiple source owners creates one build group. Wodby starts every supported build in that
+group and begins the deployment after every selected owner supplies a deployable build. Selecting one owner creates a
+single-owner group, while an explicit full new-build operation includes every build-source owner. A source owner that
+is not selected keeps its current deployment, or remains undeployed, until its own build or a later full deployment.
+
+Linked image targets are part of their source owner's build; they are not separate source owners and do not add another
+build requirement to the group.
 
 Build image targets without their own build source are optional. If a build does not produce an image for one of those services, Wodby deploys the service with the configured image from the service manifest or chart. This lets pipelines build `nginx` only when the app needs custom static assets, while still allowing `nginx` to deploy normally as part of the stack.
 

--- a/2.0/docs/apps/deploys.md
+++ b/2.0/docs/apps/deploys.md
@@ -7,13 +7,6 @@ services. If two linked services are deployed together, the linked target servic
 
 Deployments use automatic rollback by default. Rollback is best-effort and applies to the app service release that fails.
 
-During the first deployment, Wodby deploys services without a build source immediately. Services with build sources
-usually leave the app instance in `awaiting` until their [CI system](../cicd/index.md) supplies build information. If
-an app uses both Wodby CI and third-party CI sources, Wodby starts the built-in builds and keeps the deployment awaiting
-the external builds; deployment begins only after every source owner has a deployable build. Optional build image
-targets without their own build source can still deploy with their configured service image when the build does not
-provide a custom image for them.
-
 Every deployment is associated with a specific stack revision of the app instance.
 
 Deployments require complete configuration for all enabled app services in the app instance. Wodby blocks deployment
@@ -21,10 +14,35 @@ when a service is missing a required build source, external database, integratio
 
 Deployments are usually triggered in the following ways:
 
-- first deployment after app creation
+- automatic first deployment after app creation when services can deploy immediately or build with Wodby CI
 - deployment of builds [requested from CI](../cicd/deploy.md)
 - automated partial deployments for service-level maintenance
 - manual deployment from the UI
+
+## First deployment
+
+App creation does not always pre-create a full deployment that waits for every buildable service. Initial behavior
+depends on the enabled services and who starts their builds:
+
+- An app without build-source owners starts its full deployment immediately.
+- An app whose build-source owners all use Wodby CI creates an initial build group and starts those builds. The
+  deployment waits for the Wodby CI owners in that group.
+- An app whose build-source owners all use third-party CI remains `awaiting`, but Wodby does not create a passive full
+  deployment record. The first external build reaches deployment through `wodby ci deploy`, which creates a deployment
+  for that build's released services.
+- For an app with both Wodby CI and third-party CI owners, the initial build group includes the Wodby CI owners and
+  enabled runtime services without build sources. Passive third-party owners do not block that group; their services
+  deploy when their own CI builds report back or when they are included in a later explicit operation.
+
+When an app has not yet established its runtime, a build-backed deployment also includes all enabled services without
+build sources if any of them has not deployed successfully, is unhealthy, or needs redeployment. This is an initial
+runtime safety rule, not an inferred companion relationship between independent build-source owners. Optional build
+image targets without their own source can use the image produced by their linked owner or their configured service
+image when that build does not provide one.
+
+A partial deployment can complete successfully while the app instance remains `awaiting`. The instance becomes `ok`
+only after every enabled service that requires a Wodby-managed runtime has a usable deployment. Services omitted from
+the first build group can be deployed by their own CI handoff or a later manual deployment.
 
 ## Deferred initial deployment
 
@@ -91,6 +109,11 @@ Deployments from CI are triggered with `wodby ci deploy`.
 
 Each build deployment creates a new deployment record associated with the selected build. One build can contain image outputs for multiple app services. CI-triggered deployments can also skip post-deployment scripts for the built services when needed.
 
+A CI build started outside an existing dashboard build group deploys its own released service outputs without waiting
+for unrelated build-source owners. On an app that has not established its runtime yet, Wodby also includes the enabled
+services without build sources required for that initial runtime. Other build owners remain independent and deploy
+when their own builds report back.
+
 Regular app builds can continue while the target cluster is undergoing an infrastructure upgrade. If all required
 builds become ready during the upgrade, the deployment remains `awaiting` without a deployment task. Wodby starts it
 automatically after the cluster returns to `ok`; you do not need to trigger the deployment again. If the infrastructure
@@ -112,6 +135,11 @@ In that flow you can:
 If **New build** is unavailable, the build selector explains whether the service needs a linked repository and ref, a
 previously recorded GitHub Actions or CircleCI workflow from the selected ref, or whether it uses external-only Custom
 CI. A compatible previous successful build remains selectable even when the dashboard cannot start a new one.
+
+When you select **New build** for multiple source owners, Wodby creates one awaiting deployment and starts the supported
+builds together. That deployment waits for exactly the selected owners. Selecting only one source owner does not wait
+for other buildable services in the app; a full new-build deployment includes every build-source owner and waits for
+all of them.
 
 If you deploy only a subset of services, Wodby applies that ordering only inside the selected set. Repository
 post-deployment scripts run only when the app service that owns the corresponding build is included in the selected

--- a/2.0/docs/cicd/index.md
+++ b/2.0/docs/cicd/index.md
@@ -36,9 +36,11 @@ source. Leave it unlinked when source selection belongs entirely to the external
 boilerplate sources require their Wodby CI pipeline and Git source. See
 [third-party CI source selection](third-party.md#source-selection).
 
-When a build or deployment includes services using both CI paths, Wodby starts the Wodby CI builds and the supported
-third-party builds as one operation. Deployment waits until every service that owns a build source has provided a
-deployable build.
+When a build or deployment includes services using both CI paths, Wodby starts the selected Wodby CI builds and
+supported third-party builds as one operation. The deployment waits only for the source owners selected for that
+operation. Other buildable services do not block it and deploy through their own build or a later full operation. See
+[application builds](../apps/builds.md#build-sources-and-image-targets) and
+[third-party CI deployment grouping](third-party.md#deployment-grouping).
 
 `wodby ci init` automatically detects build and git metadata from GitHub Actions, GitLab CI, and CircleCI. If the CI
 provider is not recognized, the CLI reads git metadata from the checkout and sends `provider: unknown`. Pass

--- a/2.0/docs/cicd/third-party.md
+++ b/2.0/docs/cicd/third-party.md
@@ -46,8 +46,8 @@ builds from the linked repository regardless of branch or tag until you edit the
 remain unavailable for these sources; select a ref to enable matching and supported dashboard build actions.
 
 Public and cloned boilerplate sources use Wodby CI even when the instance's Default CI is third-party. They are not
-initialized with `WODBY_APP_SERVICE_ID`. An app may contain both kinds of source; its deployment waits for builds from
-all source owners before it starts.
+initialized with `WODBY_APP_SERVICE_ID`. An app may contain both kinds of source. Each build or deployment operation
+waits only for the source owners selected for that operation rather than every source owner in the app.
 
 ## Dashboard-triggered builds
 
@@ -66,12 +66,34 @@ When these requirements are not met, Wodby disables **New build** and shows the 
 recorded workflow, or provider capability. Existing successful builds remain available for deployment when otherwise
 compatible.
 
+## Deployment grouping
+
+Selecting **New build** for multiple third-party CI source owners creates one deployment group. Wodby dispatches every
+supported provider build and keeps the deployment `awaiting` until exactly those selected owners report deployable
+builds. An unselected build-source owner does not block the group. If a multi-owner dispatch is only partly successful,
+repeating the task retries targets that returned a provider error without starting another run for targets whose
+dispatch was already attempted.
+
+Provider workflows do not currently return a Wodby launch identifier that can distinguish two unresolved dashboard
+requests for the same source owner. Wodby therefore allows only one awaiting dashboard build requirement per source
+owner. Finish or cancel that request before starting another deployment group containing the same owner.
+
+When an externally started workflow reports a build, Wodby uses it for an existing dashboard group only when that group
+is awaiting that source owner. Otherwise, `wodby ci deploy` creates a standalone deployment for the build's released
+service outputs and does not wait for unrelated source owners. Custom CI always starts externally and follows this
+handoff flow.
+
+For a newly created app whose build-source owners all use third-party CI, Wodby does not pre-create a passive full
+deployment. The app remains `awaiting` until the first external build is deployed. If the app mixes Wodby CI and
+third-party CI, its initial Wodby CI group can deploy without waiting for passive external owners. The app itself stays
+`awaiting` until every enabled service that requires a Wodby-managed runtime has a usable deployment.
+
 ## Builds without a linked Git repository
 
 Without a linked Git repository, Wodby cannot poll the CI provider for the build status. After `wodby ci init`, run
-`wodby ci deploy` within three hours. Otherwise, Wodby marks the build as errored and cancels its awaiting deployment.
-A later deploy attempt cannot reopen the expired build; restart the CI workflow so it initializes a new build and
-deployment.
+`wodby ci deploy` within three hours. Otherwise, Wodby marks the build as errored and cancels any awaiting deployment
+that expected it. A later deploy attempt cannot reopen the expired build; restart the CI workflow so it initializes a
+new build and deployment.
 
 ## Typical flow
 


### PR DESCRIPTION
## Summary

- explain how single-service, multi-service, and full build operations wait for their exact selected source owners
- document first-deployment behavior for Wodby CI, external-only third-party CI, mixed CI, and services without build sources
- clarify standalone third-party CI handoffs, overlapping dashboard requests, and app status after partial initial deployment

## Validation

- `cd 2.0 && mkdocs build --strict -d /tmp/wodby-docs-build-cohorts-site`
- `git diff --check`

## Rollout

Publish these pages with the deployment build-group behavior they describe.