### PR TITLE
Document app instance maintenance mode

### DIFF
--- a/2.0/docs/apps/endpoints.md
+++ b/2.0/docs/apps/endpoints.md
@@ -14,6 +14,9 @@ From `Apps > [App] > [Instance] > Endpoints` you can manage:
 Domains and redirects are stored as routes behind the scenes, so API, CLI, task, and infrastructure documentation may
 still use the term _route_. The dashboard separates them by what users configure.
 
+To temporarily replace enabled public HTTP and HTTPS routes with a fixed `503 Service Unavailable` response, use
+[app instance maintenance mode](maintenance.md).
+
 ## Domains
 
 Domains receive HTTP and HTTPS traffic for an app service. A domain matches a hostname and path, then serves the

--- a/2.0/docs/apps/index.md
+++ b/2.0/docs/apps/index.md
@@ -184,6 +184,7 @@ Review your application configuration and click _Create new app_.
 
 - [App vs app instance vs app service](app-vs-instance-vs-service.md)
 - [Instances](instances.md)
+- [Maintenance mode](maintenance.md)
 - [App access](access.md)
 - [App services](services.md)
 - [Web terminal](web-terminal.md)

--- a/2.0/docs/apps/instances.md
+++ b/2.0/docs/apps/instances.md
@@ -26,6 +26,7 @@ Each instance has its own:
 - [Environment](env.md), which is a named Env with a fixed type such as `prod`, `staging`, or `dev`
 - [Stack](stack.md) revision
 - [Endpoints](endpoints.md) to configure HTTP routes and published ports
+- [Maintenance mode](maintenance.md) to temporarily replace public HTTP routes with a maintenance response
 - [App Access](access.md) to choose public, identity-protected, or private-network HTTP access
 - [Builds](builds.md) and [deploys](deploys.md), when the stack has services with build configuration
 - CI provider and container registry selections
@@ -80,6 +81,10 @@ public boilerplate when the same boilerplate is available in the selected stack 
     the `Databases` section and select a different database server or choose `Create new` in the `DB` field.
 
 ## Pausing and resuming an instance
+
+Pausing and [maintenance mode](maintenance.md) serve different purposes. Maintenance mode keeps workloads running and
+temporarily replaces public HTTP routes with a maintenance response. Pause an instance when you want its application
+workloads and scheduled jobs to stop.
 
 Open an app instance's `Settings` tab. Settings opens on `Edit` by default; select `Pause & Resume`, then
 `Pause app instance`, when you want to stop the instance temporarily without deleting its configuration or data.
@@ -150,4 +155,5 @@ new one.
 
 - [Applications overview](index.md)
 - [App vs app instance vs app service](app-vs-instance-vs-service.md)
+- [Maintenance mode](maintenance.md)
 - [Application stack](stack.md)

--- a/2.0/docs/apps/maintenance.md
+++ b/2.0/docs/apps/maintenance.md
@@ -1,0 +1,99 @@
+# Maintenance mode
+
+App instance maintenance mode temporarily replaces enabled public HTTP and HTTPS routes with a Wodby maintenance
+response. Use it when visitors should see a consistent maintenance page while you continue running deployments,
+migrations, or other work inside the application.
+
+Maintenance mode changes routing only. It does not stop application workloads or change the app instance lifecycle
+status.
+
+## Enable maintenance mode
+
+1. Open `Apps > [App] > [Instance] > Settings > Maintenance`.
+2. Select `Enable maintenance mode`.
+3. Review the affected traffic and confirm.
+4. Follow the routing task if the dashboard opens it.
+
+The maintenance status moves from `Off` to `Enabling` while Wodby applies the routing change, then to `Active` after
+the public edge confirms it. The app instance keeps its normal lifecycle status, such as running, deploying, awaiting,
+or errored. Instance headers and lists show a separate maintenance badge.
+
+Enabling maintenance mode requires a non-infrastructure app instance with ready platform-managed routing. You can
+change maintenance mode while the instance is running, awaiting a deployment, errored, or deploying. The cluster must
+support the direct-response routing capability used for the fixed page. If the capability is unavailable, the
+dashboard leaves maintenance mode off and explains the requirement.
+
+## Traffic behavior
+
+While maintenance mode is active, every enabled public Wodby HTTP or HTTPS route for the app instance returns the same
+fixed page with:
+
+- HTTP status `503 Service Unavailable`
+- `Retry-After: 300`, asking clients to retry after five minutes
+- `Cache-Control: no-store`
+- search-engine no-index headers
+
+The page is served at the public edge and does not depend on an application container. It is fixed and cannot be
+customized. Existing hostname and path matching, TLS certificates, HTTP-to-HTTPS redirects, and HTTP basic
+authentication remain in place.
+
+Maintenance mode also covers public redirect routes. A route configured to redirect to another destination returns
+the maintenance response until maintenance mode is disabled.
+
+The following traffic is not replaced:
+
+- routes marked private
+- routes suppressed because [App Access](access.md) publishes them through a protected or private provider path
+- published TCP or UDP ports
+
+With Selected endpoints App Access, any ordinary public routes outside the selected scope still receive the
+maintenance response. Provider-managed protected or private endpoints continue using their normal provider path.
+
+## Workloads, tasks, and billing
+
+Application workloads remain running. Scheduled jobs, builds, deploys, backups, and other application operations
+continue according to their normal rules. Maintenance mode does not reduce app-service plan usage or infrastructure
+costs.
+
+A workload deployment and a maintenance request can overlap. When necessary, Wodby waits for the workload deployment
+before applying the pending routing change. Follow the routing task to see its progress or failure details.
+
+You cannot pause an app instance while maintenance mode is requested or active. Disable maintenance mode and wait for
+its status to return to `Off`, then use `Settings > Pause & Resume`. See
+[Pausing and resuming an instance](instances.md#pausing-and-resuming-an-instance).
+
+## Disable or reverse maintenance mode
+
+Open `Settings > Maintenance` and select `Disable maintenance mode`. The status changes to `Disabling` while Wodby
+restores application backends to the public routes, then returns to `Off` after the public edge confirms the change.
+Visitors may continue to receive the maintenance response during this transition.
+
+You can reverse a pending request. For example, select `Disable maintenance mode` while the status is `Enabling`, or
+select `Enable maintenance mode` while it is `Disabling`. Wodby finishes or supersedes the in-progress routing change
+and converges on the latest requested state.
+
+If a routing task fails, the requested and active states can differ. The dashboard continues to show `Enabling` or
+`Disabling` instead of reporting a completed change. Review the task logs, correct the routing or cluster problem, and
+retry the failed routing task.
+
+## Maintenance mode compared with pausing
+
+| Behavior | Maintenance mode | Paused instance |
+| --- | --- | --- |
+| Public HTTP and HTTPS routes | Fixed `503` maintenance response | Do not respond |
+| Application workloads | Continue running | Stop |
+| Scheduled jobs | Continue normally | Stop and skip runs that become due |
+| Builds and deploys | Continue normally | Cannot start |
+| Persistent data | Remains provisioned | Remains provisioned |
+| App-service plan usage | Unchanged | Stops after pause completes |
+| TCP and UDP ports | Unchanged | Do not respond with the stopped workloads |
+
+Use maintenance mode when the application must keep running behind a temporary public response. Use pause when the
+instance is not needed and its workloads should release compute and memory.
+
+## Related pages
+
+- [App instances](instances.md)
+- [Endpoints](endpoints.md)
+- [App access](access.md)
+- [Deploys and routing deployments](deploys.md#routing-deployments)

--- a/2.0/mkdocs.yml
+++ b/2.0/mkdocs.yml
@@ -195,6 +195,7 @@ nav:
   - Apps:
       - Overview: apps/index.md
       - Instances: apps/instances.md
+      - Maintenance mode: apps/maintenance.md
       - Stack: apps/stack.md
       - App services: apps/services.md
       - Environment variables: apps/environment-variables.md


### PR DESCRIPTION
## Summary

- add a customer-facing guide for enabling, disabling, and observing app instance maintenance mode
- document the fixed 503 response, traffic exclusions, workload and billing behavior, convergence states, and failure handling
- compare maintenance mode with pausing and link the guide from Apps navigation, Instances, Endpoints, and the Apps overview

## Validation

- built the Wodby 2 documentation with MkDocs strict mode through the Wodby CLI
- verified the new navigation entry and internal links in the rendered site
- reviewed the changed content and pull request metadata for private repository or internal traceability references

## Publication

Publish this documentation when the maintenance-mode controls and API are available to users.