### PR TITLE
Document building only part of a repository, and when a Dockerfile is needed

### DIFF
--- a/2.0/docs/cicd/build.md
+++ b/2.0/docs/cicd/build.md
@@ -23,7 +23,25 @@ ARG COPY_TO
 COPY --chown={{.DefaultUser}}:{{.DefaultUser}} ${COPY_FROM} ${COPY_TO}
 ```
 
-`WODBY_BASE_IMAGE` comes from the current stack definition. `COPY_FROM` and `COPY_TO` default to `.` and can be changed with `--from` and `--to`.
+`WODBY_BASE_IMAGE` comes from the current stack definition. `COPY_FROM` and `COPY_TO` default to `.` and can be changed with `--from` and `--to`. When a service sets `build.copySubdir`, that subdirectory is appended to both, so the flags give the roots and the service gives the path within them.
+
+## Building from your own Dockerfile
+
+A Dockerfile taken from the repository, whether by `--dockerfile` or as `<service>_Dockerfile` in the build context, must build from the service image:
+
+```dockerfile
+ARG WODBY_BASE_IMAGE
+FROM ${WODBY_BASE_IMAGE}
+```
+
+In a multi-stage build the final stage must be the one that uses it. After the build the CLI compares image layers to confirm this, and fails when the image is not derived from the service image. Such an image stops receiving service image updates while Wodby continues to report the app service as running the service image version.
+
+Pass `--allow-unmanaged-image` to build anyway. The build then warns, and the image is recorded as unmanaged so the app build view shows that it no longer tracks service image versions.
+
+Two things worth knowing when maintaining your own Dockerfile:
+
+- You do not need to run the service init action. Service images apply it on container start, so a `RUN make init-...` line is redundant, though harmless because the action is idempotent.
+- An `ARG` only receives a value when the matching service setting or environment variable is marked as a build argument. An `ARG` with no such value expands to an empty string rather than failing the build, so a `COPY` written in terms of it copies a different path.
 
 The matching ignore file is `<dockerfile>.dockerignore`. If it is not present in the build context, the CLI falls back to the `.dockerignore` from the Wodby service config or to a small default ignore list.
 

--- a/2.0/docs/services/build.md
+++ b/2.0/docs/services/build.md
@@ -55,19 +55,49 @@ repository overrides the app instance's Default CI for that app service and uses
 
 ### Dockerfile
 
-Services can specify a custom Dockerfile in the service manifest. Use `build.dockerfile` for a path in the same
-repository; it is resolved relative to the directory containing `service.yml` and must exist. Use
-`build.dockerignore` for the matching ignore file. Wodby CI uses this configuration during
-`wodby ci build [service]`.
+Most services do not need one. Wodby CI generates a Dockerfile that builds from the service image and copies the
+codebase into it, which is all a typical service requires.
 
-Use `build.dockerfileContent` or `build.dockerignoreContent` when the content is defined inline in `service.yml`. Do not
+Provide one only when the image needs build steps the generated Dockerfile cannot express, such as compiling
+dependencies. Use `build.dockerfile` for a path in the same repository; it is resolved relative to the directory
+containing `service.yml` and must exist. Use `build.dockerignore` for the matching ignore file. Use
+`build.dockerfileContent` or `build.dockerignoreContent` when the content is defined inline in `service.yml`. Do not
 specify a path field and its corresponding content field together.
+
+Preparing the codebase for the image is not a reason to provide one. Service images apply their own init action when
+the container starts, so a Dockerfile does not have to run it. To narrow the build to part of the repository, use
+`build.copySubdir` below.
+
+### Copying part of the repository
+
+A service that needs only one directory of the repository, such as a web server that serves the docroot while the
+application runs in a linked service, sets `build.copySubdir`:
+
+```yaml
+build:
+  link: backend
+  copySubdir: "{{settings.docroot}}"
+```
+
+The value is a subdirectory, applied to both the source and the destination, so the path is preserved: the codebase at
+`web` in the repository lands at `web` under the image working directory. Both sides use the same value because a web
+server and the application it passes requests to must resolve the docroot to the same absolute path.
+
+It may reference a service setting as `{{settings.<name>}}`, so the value follows whatever the user configures rather
+than being fixed in the manifest. The setting must be declared by the same manifest and must not be secret; import
+fails otherwise, as it does for an absolute path or one containing `..`.
+
+Leave `copySubdir` unset to copy the whole build context, which is the default.
 
 ### Build arguments
 
-Docker build arguments are explicit. If a service Dockerfile declares an `ARG`, Wodby passes a value only when the
+Docker build arguments are explicit. If a Dockerfile declares an `ARG`, Wodby passes a value only when the
 corresponding service setting, service environment variable, or app-service environment variable is marked
-`build: true`.
+`build: true`. This applies to a Dockerfile provided by the service and to one provided by the app being built; the
+generated Dockerfile declares only `WODBY_BASE_IMAGE`, `COPY_FROM` and `COPY_TO`.
+
+An `ARG` with no matching build-scoped value is not an error. Docker expands it to an empty string, so a `COPY` written
+in terms of it silently copies a different path.
 
 Runtime values are not passed to image builds by default. This keeps deployment-only configuration and integration
 credentials out of the build environment unless a value is deliberately marked as a build input.

--- a/2.0/docs/services/template.md
+++ b/2.0/docs/services/template.md
@@ -421,6 +421,8 @@ Each object supports:
 - `dockerignore`: relative repository path to `.dockerignore` content. The file must exist.
 - `dockerfileContent`: inline Dockerfile content.
 - `dockerignoreContent`: inline `.dockerignore` content.
+- `copySubdir`: subdirectory of the repository this build copies, applied to both the source and the destination so the
+  path is preserved. May reference a service setting as `{{settings.<name>}}`. Leave unset to copy the whole context.
 - `connect`: whether the service supports a connected git repository.
 - `link`: service link whose target owns the build source for this image target.
 - `boilerplates`: starter repositories users can clone as a starting point.
@@ -434,6 +436,10 @@ builds. Do not combine `build.link` with `connect: true`, `boilerplates`, or the
 
 Docker build arguments are opt-in. Wodby passes only values marked with `build: true` from service env vars, service
 settings, or app-service env vars. Runtime-only values are not passed to builds.
+
+A `copySubdir` reference is resolved from the setting itself and does not require `build: true`. The referenced setting
+must be declared by the same manifest and must not be secret, and the value must be a relative path without `..`;
+import fails otherwise.
 
 Each `build.boilerplates[]` item supports:
 


### PR DESCRIPTION
## Why

Services used to ship a Dockerfile purely to express that an image needs one directory of the repository — a web server serving the docroot while the application runs in a linked service. They now set `build.copySubdir` instead, and the platform generates the Dockerfile.

That makes three pages out of date, in ways that would actively mislead someone writing a service today.

## Changes

**`2.0/docs/services/build.md`** — the Dockerfile section presented a custom Dockerfile as the normal path. It is now the exception, so the page says when one is genuinely needed and states that preparing the codebase is not among those reasons, since service images apply their init action on container start. Adds a section on `build.copySubdir`, including why one value covers both sides: a web server and the application it forwards to must resolve the docroot to the same absolute path.

**`2.0/docs/services/template.md`** — adds `copySubdir` to the `build` field reference, and notes that a `{{settings.<name>}}` reference resolves from the setting itself and so does not require `build: true`, along with the conditions that fail import.

**`2.0/docs/cicd/build.md`** — notes that `copySubdir` is appended to `--from` and `--to`, and adds a section on building from your own Dockerfile: it must build `FROM` the service image or the build fails, `--allow-unmanaged-image` overrides that at the cost of no longer tracking service image versions, the init action no longer needs running by hand, and an `ARG` with no build-scoped value expands to an empty string rather than failing.

## Validation

`mkdocs build --strict` on `2.0/` succeeds, matching what the docs workflow runs.