### PR TITLE
Document deployment configuration

### DIFF
--- a/2.0/docs/apps/services.md
+++ b/2.0/docs/apps/services.md
@@ -74,7 +74,7 @@ Inside `Apps > [App] > [Instance] > Stack > App services > [Service]`, the dashb
 primary tabs:
 
 - `Overview`
-- `Configuration`: `General`, `Variables`, `Helm`, `Settings`, `Configs`, `Tokens`, and `Annotations`
+- `Configuration`: `General`, `Deployment`, `Variables`, `Helm`, `Settings`, `Configs`, `Tokens`, and `Annotations`
 - `Connections`: `Integrations`, `Links`, and `Database`
 - `Runtime`: `Resources` and `Volumes`
 - `Actions`
@@ -91,7 +91,7 @@ In general:
 - `Metrics` appears only when cluster monitoring is enabled and the app service is not external or disabled
 - `Actions` appears only when the service defines user-runnable actions
 - `Database` appears only for services with database support
-- `Variables`, `Helm`, and `Resources` appear only for non-external services
+- `Deployment`, `Variables`, `Helm`, and `Resources` appear only for non-external services
 - `Links`, `Volumes`, `Settings`, and `Configs` appear only when the service supports them
 - `Tokens` appear only for non-external top-level services
 - `Annotations` appear only for non-external services
@@ -236,6 +236,17 @@ This is commonly used for storage, mail, monitoring, or other provider-backed fe
 Variable integrations inject provider-wide fields and fields from the matching selected kind into runtime containers
 only. Fields owned by other provider kinds are not injected through that service requirement. Variable integration
 values are not passed to image builds.
+
+## Deployment tab
+
+The `Configuration > Deployment` subtab controls rollout strategy, readiness timing, and graceful shutdown for this app
+service. Use `All workloads` for service-wide settings. Services with multiple workloads also show workload cards for
+targeted overrides.
+
+Each unset field inherits independently from the stack service or service manifest. If no inherited value exists, the
+Helm chart keeps its default. Saving a deployment override marks the app instance as needing redeploy. See
+[Deployment configuration](../services/deployment.md) for supported settings, workload-kind restrictions, and the full
+precedence order.
 
 <a id="env-vars-tab"></a>
 

--- a/2.0/docs/services/deployment.md
+++ b/2.0/docs/services/deployment.md
@@ -1,0 +1,112 @@
+# Deployment configuration
+
+Deployment configuration controls how Kubernetes replaces pods during an update, how long a new pod must stay ready,
+and how long a terminating pod has to shut down. Service authors can provide defaults, stack authors can override them
+for every app created from a stack, and app operators can tune one app service without changing the stack.
+
+Wodby passes only configured deployment settings to Helm. If a setting is not configured at any level, the chart keeps
+its own default. Deployment configuration is not available for external services.
+
+## Configure deployment behavior
+
+For a stack service, open
+`Stack > Stack services > [Service] > Configuration > Deployment`. Changes are saved to the stack draft and take effect
+after the draft is published and an app is created or upgraded to that stack revision.
+
+For one app service, open
+`Apps > [App] > [Instance] > Stack > App services > [Service] > Configuration > Deployment`. Saving an override marks
+the app instance as needing redeploy.
+
+Use `All workloads` for service-wide settings. Services with multiple workloads also show a card for each workload, so
+a setting can be overridden only for the workload that needs different behavior. Leaving a field empty inherits the
+next applicable value; if no inherited value exists, the chart default is used.
+
+## Inheritance and precedence
+
+Each field is resolved independently. From lowest to highest precedence, the sources are:
+
+1. service manifest `deployment`
+2. service manifest `workloads[].deployment`
+3. stack service `deployment`
+4. stack service `workloads[].deployment`
+5. app service `deployment`
+6. app service workload override
+
+For example, an app-level shutdown grace period can coexist with a workload-specific rolling-update limit inherited
+from the service manifest.
+
+## Settings
+
+| Setting | Purpose | Supported workload kinds |
+| --- | --- | --- |
+| `strategy` | Selects how Kubernetes updates the workload | Deployment, StatefulSet, DaemonSet |
+| `maxUnavailable` | Maximum unavailable pods during a rolling update | Deployment, StatefulSet, DaemonSet |
+| `maxSurge` | Maximum extra pods during a rolling update | Deployment, DaemonSet |
+| `minReady` | Time a pod must remain ready before it is considered available | Deployment, StatefulSet, DaemonSet |
+| `progressDeadline` | Maximum time a Deployment rollout may make no progress | Deployment |
+| `shutdownGracePeriod` | Time Kubernetes gives containers to stop before forcefully terminating them | Deployment, StatefulSet, DaemonSet |
+
+`maxUnavailable` and `maxSurge` accept a non-negative integer or a percentage from `0%` through `100%`. They apply only
+to a rolling strategy and cannot both be zero. StatefulSets do not support `maxSurge`.
+
+Durations use Go duration syntax, for example `10s`, `5m`, or `10m30s`, and must resolve to whole seconds.
+`progressDeadline` must be greater than zero and, when `minReady` is also configured, greater than `minReady`.
+
+### Strategies
+
+| Manifest value | Kubernetes behavior | Supported workload kinds |
+| --- | --- | --- |
+| `rolling` | Gradually replaces old pods with new pods | Deployment, StatefulSet, DaemonSet |
+| `recreate` | Stops all old pods before creating new pods | Deployment |
+| `onDelete` | Replaces pods only when they are deleted manually | StatefulSet, DaemonSet |
+
+## Service manifest defaults
+
+Set defaults for a single-workload service at the top level:
+
+```yaml
+deployment:
+  strategy: rolling
+  maxUnavailable: 0
+  maxSurge: 1
+  minReady: 10s
+  progressDeadline: 15m
+  shutdownGracePeriod: 11m
+```
+
+For a service with multiple workloads, put workload-specific behavior under each workload:
+
+```yaml
+workloads:
+  - name: web
+    kind: deployment
+    deployment:
+      maxUnavailable: 0
+      maxSurge: 1
+      shutdownGracePeriod: 11m
+  - name: worker
+    kind: deployment
+    deployment:
+      shutdownGracePeriod: 2m
+```
+
+Stack manifests use the same fields under `services[].deployment` and `services[].workloads[].deployment`. See the
+[stack template reference](../stacks/template.md#servicesdeployment).
+
+## Helm chart integration
+
+For a service with one workload, Wodby uses these default Helm paths:
+
+| Setting | Deployment | StatefulSet | DaemonSet |
+| --- | --- | --- | --- |
+| `strategy` | `strategy` | `updateStrategy` | `updateStrategy` |
+| `minReady` | `minReadySeconds` | `minReadySeconds` | `minReadySeconds` |
+| `progressDeadline` | `progressDeadlineSeconds` | Not supported | Not supported |
+| `shutdownGracePeriod` | `terminationGracePeriodSeconds` | `terminationGracePeriodSeconds` | `terminationGracePeriodSeconds` |
+
+`maxUnavailable` and `maxSurge` are written below the mapped strategy path as `rollingUpdate.maxUnavailable` and
+`rollingUpdate.maxSurge`.
+
+Charts with different paths can override `helm.valueMappings.strategy`, `minReady`, `progressDeadline`, and
+`shutdownGracePeriod`. Charts with multiple workloads must define the corresponding mappings under each
+`workloads[].helm` object. See [Service Helm Integration](helm.md#deployment-value-mappings) for examples.

--- a/2.0/docs/services/helm.md
+++ b/2.0/docs/services/helm.md
@@ -33,6 +33,10 @@ Wodby works best with charts that expose common values such as:
 - `serviceAccountName` or another value that sets `spec.template.spec.serviceAccountName`
 - `image.pullSecrets`
 - `image.pullPolicy`
+- `strategy` or `updateStrategy`
+- `minReadySeconds`
+- `progressDeadlineSeconds`
+- `terminationGracePeriodSeconds`
 - `autoscaling`
 - `image.repository`, `image.tag`, `image.registry`
 - `command`
@@ -45,7 +49,7 @@ multiple workloads, where each workload may have its own image values.
 
 Wodby injects several values that control the app service itself. The optional `helm.valueMappings` object maps those
 settings to paths exposed by the chart. Existing service manifests remain compatible because every omitted mapping
-uses the legacy default:
+uses its documented compatibility default:
 
 | App-service setting | Default Helm value path |
 | --- | --- |
@@ -53,6 +57,10 @@ uses the legacy default:
 | Full resource-name override | `fullnameOverride` |
 | Kubernetes service account name | `serviceAccountName` |
 | Disable chart-owned service account creation | No default; configure `serviceAccountCreate` when needed |
+| Rollout strategy | `strategy` for Deployments; `updateStrategy` for StatefulSets and DaemonSets |
+| Minimum ready duration | `minReadySeconds` |
+| Deployment progress deadline | `progressDeadlineSeconds` |
+| Pod shutdown grace period | `terminationGracePeriodSeconds` |
 
 Override only the paths that differ from these defaults. For example, a chart that nests its deployment values can
 define:
@@ -68,6 +76,10 @@ helm:
     fullnameOverride: workload.fullnameOverride
     serviceAccountName: serviceAccount.name
     serviceAccountCreate: serviceAccount.create
+    strategy: workload.strategy
+    minReady: workload.minReadySeconds
+    progressDeadline: workload.progressDeadlineSeconds
+    shutdownGracePeriod: workload.terminationGracePeriodSeconds
 ```
 
 An explicit `replicas` mapping replaces both legacy replica aliases with the configured path. Each other property is
@@ -94,6 +106,51 @@ that break the rendered workload contract are rejected by import validation.
 When a chart keeps the full image path inside one repository value and does not expose a separate registry field, set
 `workloads[].containers[].helm.image.registry: ""`. This disables separate registry injection and makes Wodby write the
 full repository path into the configured `repository` value instead.
+
+## Deployment value mappings
+
+Deployment configuration is optional. Wodby writes only the fields configured by the service, stack, or app service;
+an unset field remains absent from the generated Helm values so the chart can apply its own default.
+
+For a service with one workload, the compatibility defaults are:
+
+| Mapping | Deployment | StatefulSet | DaemonSet |
+| --- | --- | --- | --- |
+| `strategy` | `strategy` | `updateStrategy` | `updateStrategy` |
+| `minReady` | `minReadySeconds` | `minReadySeconds` | `minReadySeconds` |
+| `progressDeadline` | `progressDeadlineSeconds` | Not supported | Not supported |
+| `shutdownGracePeriod` | `terminationGracePeriodSeconds` | `terminationGracePeriodSeconds` | `terminationGracePeriodSeconds` |
+
+The configured `maxUnavailable` and `maxSurge` values are written below the strategy path as
+`rollingUpdate.maxUnavailable` and `rollingUpdate.maxSurge`.
+
+Override only paths that differ from these defaults:
+
+```yaml
+helm:
+  valueMappings:
+    strategy: controller.updateStrategy
+    minReady: controller.minReadySeconds
+    progressDeadline: controller.progressDeadlineSeconds
+    shutdownGracePeriod: controller.terminationGracePeriodSeconds
+```
+
+Service-level deployment mappings are resolved only for a service with one workload. A chart that renders multiple
+workloads must define each workload's paths explicitly:
+
+```yaml
+workloads:
+  - name: server
+    kind: deployment
+    helm:
+      strategy: server.strategy
+      minReady: server.minReadySeconds
+      progressDeadline: server.progressDeadlineSeconds
+      shutdownGracePeriod: server.terminationGracePeriodSeconds
+```
+
+See [Deployment configuration](deployment.md) for the supported settings, strategies, workload kinds, and inheritance
+rules.
 
 ## Import validation
 

--- a/2.0/docs/services/index.md
+++ b/2.0/docs/services/index.md
@@ -48,6 +48,7 @@ Use these pages when creating or maintaining custom services:
 Use these pages to understand how a service deploys and connects inside an app:
 
 - [Workloads](workloads.md): Kubernetes workload mapping, selectors, containers, primary workloads, and build targets.
+- [Deployment](deployment.md): rollout strategy, readiness timing, graceful shutdown, inheritance, and workload overrides.
 - [Helm](helm.md): chart references, Helm values, and image mappings.
 - [Build](build.md): CI/CD build configuration for buildable services.
 - [Networking](networking.md): endpoints and service-to-service links.

--- a/2.0/docs/services/template.md
+++ b/2.0/docs/services/template.md
@@ -173,7 +173,7 @@ actions:
   base service.
 - Only services of type `service` can use the `build` section.
 - Only services of type `db` can use the `database` section.
-- `external: true` is for services managed outside Wodby. External services cannot define `workloads`, `build`,
+- `external: true` is for services managed outside Wodby. External services cannot define `deployment`, `workloads`, `build`,
   `links`, `volumes`, `settings`, `env`, `configs`, `actions`, `certs`, `keys`, `cron`, or `derivatives`.
 - Infrastructure services cannot be external and do not use `options`, `tokens`, or `imports`.
 - Kubernetes-facing names are validated during import and deployment. See [Naming rules](../naming.md) for service, workload, endpoint, port, volume, config, and generated resource name constraints.
@@ -358,6 +358,25 @@ has been explicitly integrated and validated.
 Wodby uses this flag for API validation, dashboard controls, Helm chart conformance, and backend-managed autoscaling.
 Fixed services accept zero or one replica; scalable services must render the requested replica count exactly.
 
+### `deployment`
+
+Type: `object`.
+
+Optional service-wide rollout, readiness, and graceful-shutdown defaults. Each field can be overridden for an individual
+workload, stack service, or app service.
+
+The object supports:
+
+- `strategy`: `rolling`, `recreate`, or `onDelete`, subject to the workload kind.
+- `maxUnavailable`: non-negative integer or percentage from `0%` through `100%`.
+- `maxSurge`: non-negative integer or percentage from `0%` through `100%`.
+- `minReady`: duration a pod must remain ready before it is considered available.
+- `progressDeadline`: maximum time a Deployment rollout may make no progress.
+- `shutdownGracePeriod`: time Kubernetes gives containers to stop before forcefully terminating them.
+
+Durations use Go duration syntax and must resolve to whole seconds. For workload-kind restrictions, precedence, and
+examples, see [Deployment configuration](deployment.md).
+
 ### `labels`
 
 Type: `array[string]`.
@@ -402,6 +421,7 @@ Each workload declares:
 - a rendered Kubernetes target selected by `selector.matchLabels`
 - a `kind`
 - one or more `containers`
+- optional workload-specific `deployment` settings
 - optional workload- and container-level Helm value mappings
 
 If the service has multiple workloads, mark one as `primary`. The primary workload is the default target used by
@@ -865,7 +885,8 @@ The object supports:
 - `chart`: required chart name.
 - `version`: required chart version.
 - `imagePullSecrets`: optional Helm value path for image pull secrets. Defaults to `image.pullSecrets`.
-- `valueMappings`: optional paths for backend-managed app-service values. Omitted mappings retain the legacy defaults.
+- `valueMappings`: optional paths for backend-managed app-service values. Omitted mappings retain the documented
+  compatibility defaults.
 - `crds`: optional CRD file list.
 - `values`: optional extra Helm values. `helm.values[].value` can use [built-in runtime tokens](../apps/tokens.md)
   and service-defined tokens.
@@ -892,12 +913,21 @@ The object supports:
 - `serviceAccountName`: Kubernetes service-account name path. Defaults to `serviceAccountName`.
 - `serviceAccountCreate`: optional chart-owned service-account creation path. Wodby sets it to `false` when it supplies
   an annotated service account. There is no compatibility default because not every chart creates an account.
+- `strategy`: rollout-strategy path. Defaults to `strategy` for a Deployment and `updateStrategy` for a StatefulSet or
+  DaemonSet.
+- `minReady`: minimum-ready-seconds path. Defaults to `minReadySeconds`.
+- `progressDeadline`: Deployment progress-deadline-seconds path. Defaults to `progressDeadlineSeconds`.
+- `shutdownGracePeriod`: pod termination-grace-period-seconds path. Defaults to `terminationGracePeriodSeconds`.
 
 `serviceAccountName` must be explicit for service revisions that can use workload identity for an external database.
 If the chart creates the named account, `serviceAccountCreate` is required as well.
 
 Autoscaling paths are intentionally not part of `valueMappings`. Wodby owns the HorizontalPodAutoscaler and continues
 to pass the ordinary replica value to the chart.
+
+Deployment mappings at this level apply only to a service with one workload. Charts with multiple workloads define
+these mappings under `workloads[].helm`. Wodby writes only deployment fields that have an effective configured value;
+unset fields remain controlled by the chart. See [Deployment value mappings](helm.md#deployment-value-mappings).
 
 Example:
 

--- a/2.0/docs/services/workloads.md
+++ b/2.0/docs/services/workloads.md
@@ -104,8 +104,12 @@ Each `workloads[]` item supports:
 - `selector`: required Kubernetes selector used by Wodby to find the rendered workload resource.
 - `kind`: required workload kind. Allowed values: `deployment`, `statefulset`, `daemonset`.
 - `primary`: optional boolean. Marks the default workload for runtime operations.
+- `deployment`: optional workload-specific rollout, readiness, and graceful-shutdown settings.
 - `helm`: optional workload-level Helm mappings.
 - `containers`: required list of containers for this workload.
+
+Workload deployment settings override service-wide defaults one field at a time. See
+[Deployment configuration](deployment.md) for supported settings and workload-kind restrictions.
 
 ### Workload names
 
@@ -202,8 +206,16 @@ See also: [Service build](build.md).
 - `annotations`
 - `volumes`
 - `sidecars`
+- `strategy`
+- `minReady`
+- `progressDeadline`
+- `shutdownGracePeriod`
 
 These are Helm value paths used when Wodby injects workload-scoped data.
+
+The four deployment paths are required for charts with multiple workloads when the corresponding setting needs to be
+passed to Helm. Service-level deployment mapping defaults apply only to single-workload services. See
+[Deployment value mappings](helm.md#deployment-value-mappings).
 
 ### Container-level Helm mappings
 

--- a/2.0/docs/stacks/configuration.md
+++ b/2.0/docs/stacks/configuration.md
@@ -91,6 +91,16 @@ service. Stacks without an eligible service can have no main service.
 You can set the number of replicas per service. This is not available for external services. Fixed services accept
 zero or one replica; services whose revision supports horizontal scaling can use higher replica counts.
 
+### Deployment
+
+Configure rollout strategy, readiness timing, and graceful shutdown from
+`Stack > Stack services > [Service] > Configuration > Deployment`. Use `All workloads` for service-wide settings and,
+for services with multiple workloads, use a workload card only where different behavior is needed.
+
+Unset fields inherit service-manifest defaults or remain controlled by the Helm chart. Saving changes updates the
+stack draft; publish the draft and upgrade app instances to apply them. See
+[Deployment configuration](../services/deployment.md) for supported values and precedence.
+
 ### Build source
 
 When a stack service supports a connected build source, `Configuration > General` also shows a separate `Build source`

--- a/2.0/docs/stacks/template.md
+++ b/2.0/docs/stacks/template.md
@@ -302,6 +302,25 @@ Type: `integer`. Default: `1`.
 Default number of replicas for the stack service. Fixed service revisions accept `0` or `1`; service revisions that
 support horizontal scaling can use higher values.
 
+### `services[].deployment`
+
+Type: `object`.
+
+Service-wide deployment overrides for every app created from this stack revision. Each property overrides the matching
+service-manifest default independently.
+
+The object supports:
+
+- `strategy`
+- `maxUnavailable`
+- `maxSurge`
+- `minReady`
+- `progressDeadline`
+- `shutdownGracePeriod`
+
+For field formats, workload-kind restrictions, and precedence, see
+[Deployment configuration](../services/deployment.md).
+
 ### `services[].main`
 
 Type: `boolean`.
@@ -364,7 +383,11 @@ Per-workload overrides for workloads defined by the referenced service.
 Each item supports:
 
 - `name`: required workload name from the referenced service manifest. It must follow the [general Kubernetes name rules](../naming.md#general-kubernetes-names).
-- `containers`: required list of container overrides for that workload.
+- `deployment`: optional deployment override for this workload. It supports the same fields as
+  `services[].deployment`.
+- `containers`: optional list of container overrides for that workload.
+
+Each workload override must contain `deployment`, `containers`, or both.
 
 Each `services[].workloads[].containers[]` item supports:
 
@@ -466,6 +489,9 @@ Each item supports:
 - `required`: optional boolean.
 - `env`: optional environment variables.
 - `helm`: optional Helm values.
+- `deployment`: optional service-wide deployment overrides.
+- `workloads`: optional workload-specific deployment and container overrides, with the same shape as
+  `services[].workloads`.
 
 Only derivatives declared by the referenced service can be used here. Derivative stack service names follow the same
 [Kubernetes service name rules](../naming.md#kubernetes-service-names) as `services[].name`.

--- a/2.0/mkdocs.yml
+++ b/2.0/mkdocs.yml
@@ -266,6 +266,7 @@ nav:
       - Template: services/template.md
       - Types: services/types.md
       - Workloads: services/workloads.md
+      - Deployment: services/deployment.md
       - Helm: services/helm.md
       - Build: services/build.md
       - Networking: services/networking.md


### PR DESCRIPTION
## Summary

- explain rollout, readiness, and graceful-shutdown settings at stack and app-service scope
- document field-by-field inheritance and per-workload overrides
- document service and stack manifest fields, validation rules, and Helm value mappings

## Validation

- `cd 2.0 && mkdocs build --strict`