### PR TITLE
Document paid Application Access availability

### DIFF
--- a/2.0/docs/apps/access.md
+++ b/2.0/docs/apps/access.md
@@ -3,6 +3,15 @@
 App access controls whether an app instance is published through ordinary Wodby routes or through a supported access
 provider. It applies to HTTP endpoints and is configured independently for each app instance.
 
+## Availability
+
+Application Access requires an active paid subscription. Organizations on the free Developer plan can create apps in
+`Public` mode, but `Protected` mode is unavailable until the organization upgrades.
+
+Before scheduling a downgrade to Developer, remove Application Access from every app instance. If paid access becomes
+unavailable while an existing configuration remains, its protection stays active and readable, but it cannot be
+changed. You can still remove it, and Wodby can still finish provider cleanup.
+
 ## Modes
 
 The app creation form offers two modes:

--- a/2.0/docs/pricing.md
+++ b/2.0/docs/pricing.md
@@ -36,6 +36,7 @@ Team includes everything in Developer, plus production-focused features such as:
 - backup presets and automatic backups
 - scheduled and manually run cron jobs
 - web shell for containers
+- Application Access for protected or private-network HTTP endpoints
 - best-effort support
 - $30 of Wodby Cloud usage per month
 
@@ -107,7 +108,11 @@ After a downgrade is scheduled:
 - new paid-only features and capacity above the Developer plan limit are not available
 
 To schedule a downgrade, the organization must already fit the Developer plan limits and must not depend on paid-only
-features. App instance pausing is a paid feature, so no instance can be `Pausing` or `Paused` when a downgrade is
+features. Application Access is a paid feature, so remove it from every app instance under **Apps > your app > your
+instance > Settings > Access** before scheduling a downgrade. The downgrade error identifies each affected app and
+instance.
+
+App instance pausing is also a paid feature, so no instance can be `Pausing` or `Paused` when a downgrade is
 scheduled. If an instance is `Pausing`, wait for it to reach `Paused`; then open **Apps > your app > your instance >
 Settings > Pause & Resume**, select **Resume app instance**, and retry the downgrade after it finishes. The downgrade
 error identifies each affected app and instance.


### PR DESCRIPTION
## Summary

- state that Application Access requires an active paid subscription
- explain Developer-plan behavior and safe removal when entitlement is unavailable
- document Application Access as a Team feature and a downgrade blocker

## Validation

- `mkdocs build --strict`