### PR TITLE
Document service-defined integration environment variables

### DIFF
--- a/2.0/docs/integrations/variable.md
+++ b/2.0/docs/integrations/variable.md
@@ -59,26 +59,27 @@ Variable integrations are typically attached to:
 1. Create or choose a provider.
 2. Create an integration from that provider and fill in its fields.
 3. Attach the integration to an app service or stack.
-4. Wodby injects the provider's environment variables into the container, using the service-defined output mapping
-   when the service declares one.
+4. Wodby injects the provider's environment variables into the container. When the service defines integration
+   environment variables, Wodby injects those instead.
 
 Variable integration env vars are runtime-only. They are not passed to Docker image builds or exported as CI build
 arguments. Use a build-scoped app-service environment variable or service setting when a Dockerfile needs a value
 during build.
 
-## Service-owned environment mappings
+## Service-defined environment variables
 
 By default, a variable integration exports matched provider variables under the names defined by the provider. A
-service author can instead declare the provider variables the service needs and map them to application-facing runtime
-names. The mapping can also add literal values owned by the service, such as a driver or mode name.
+service author can instead declare the provider variables the service needs and define the application-facing runtime
+environment variables that Wodby injects. The service can also inject literal values it owns, such as a driver or mode
+name.
 
-With a service-owned mapping:
+With service-defined environment variables:
 
 - the integration still matches a provider by the declared variable contract rather than a hard-coded provider name
-- only mapped outputs are injected, so extra provider variables are not exposed to the container
+- only the service-defined environment variables are injected, so extra provider variables are not exposed to the container
 - secret inputs must remain secret outputs
-- an exact mapping for a missing optional input is omitted
-- services without a mapping retain the default direct-export behavior
+- an environment variable that directly references a missing optional input is omitted
+- services without an `env` definition retain the default direct-export behavior
 
 See [`integrations` in the service template reference](../services/template.md#integrations) for the manifest syntax,
 validation rules, and a complete example.
@@ -91,7 +92,7 @@ If a provider is missing, you can [create a custom variable provider](../provide
 interactively, from a local manifest, or from a Git repository containing one or several provider manifests. The
 standard
 [environment-variable naming and reserved-name rules](../apps/environment-variables.md#names-and-reserved-variables)
-apply to custom mappings.
+apply to service-defined integration environment variables.
 
 Services can declare an exact variable contract instead of naming a particular provider. Wodby then accepts only
 integrations whose selected provider kind supplies the required names, secret classifications, and optionality. This is

--- a/2.0/docs/integrations/variable.md
+++ b/2.0/docs/integrations/variable.md
@@ -59,11 +59,29 @@ Variable integrations are typically attached to:
 1. Create or choose a provider.
 2. Create an integration from that provider and fill in its fields.
 3. Attach the integration to an app service or stack.
-4. Wodby injects the provider's environment variables into the container.
+4. Wodby injects the provider's environment variables into the container, using the service-defined output mapping
+   when the service declares one.
 
 Variable integration env vars are runtime-only. They are not passed to Docker image builds or exported as CI build
 arguments. Use a build-scoped app-service environment variable or service setting when a Dockerfile needs a value
 during build.
+
+## Service-owned environment mappings
+
+By default, a variable integration exports matched provider variables under the names defined by the provider. A
+service author can instead declare the provider variables the service needs and map them to application-facing runtime
+names. The mapping can also add literal values owned by the service, such as a driver or mode name.
+
+With a service-owned mapping:
+
+- the integration still matches a provider by the declared variable contract rather than a hard-coded provider name
+- only mapped outputs are injected, so extra provider variables are not exposed to the container
+- secret inputs must remain secret outputs
+- an exact mapping for a missing optional input is omitted
+- services without a mapping retain the default direct-export behavior
+
+See [`integrations` in the service template reference](../services/template.md#integrations) for the manifest syntax,
+validation rules, and a complete example.
 
 ## Built-in vs custom variable providers
 

--- a/2.0/docs/providers/variable.md
+++ b/2.0/docs/providers/variable.md
@@ -56,11 +56,11 @@ auto updates. Every custom provider page also exposes its current manifest, task
 See [Custom variable providers](custom-variable-providers.md) for the manifest format, repository layout, update rules,
 and complete dashboard workflow. The standard
 [environment-variable naming and reserved-name rules](../apps/environment-variables.md#names-and-reserved-variables)
-apply to all custom mappings.
+apply to all service-defined integration environment variables.
 
 Variables exposed by variable providers are injected into runtime containers only. By default they retain the names
-defined by the provider; a [service-owned integration mapping](../services/template.md#integrations) can expose only
-selected variables under application-facing names. They are not passed to Docker image builds. Use build-scoped
+defined by the provider; [service-defined integration environment variables](../services/template.md#integrations)
+can expose only selected variables under application-facing names. They are not passed to Docker image builds. Use build-scoped
 app-service environment variables or service settings for Dockerfile build arguments.
 
 ### Matching service requirements

--- a/2.0/docs/providers/variable.md
+++ b/2.0/docs/providers/variable.md
@@ -58,8 +58,10 @@ and complete dashboard workflow. The standard
 [environment-variable naming and reserved-name rules](../apps/environment-variables.md#names-and-reserved-variables)
 apply to all custom mappings.
 
-Variables exposed by variable providers are injected into runtime containers only. They are not passed to Docker image
-builds. Use build-scoped app-service environment variables or service settings for Dockerfile build arguments.
+Variables exposed by variable providers are injected into runtime containers only. By default they retain the names
+defined by the provider; a [service-owned integration mapping](../services/template.md#integrations) can expose only
+selected variables under application-facing names. They are not passed to Docker image builds. Use build-scoped
+app-service environment variables or service settings for Dockerfile build arguments.
 
 ### Matching service requirements
 

--- a/2.0/docs/services/template.md
+++ b/2.0/docs/services/template.md
@@ -639,7 +639,7 @@ Each item supports:
 - `multiple`: optional boolean.
 - `labels`: optional labels used to filter compatible provider kinds.
 - `variables`: optional environment-variable contract for a variable integration.
-- `env`: optional provider-independent output mapping for a variable integration.
+- `env`: optional service-defined environment variables injected from a variable integration.
 - `providers`: optional provider-specific overrides.
 
 An attached integration is compatible only when one of its selected provider kinds has the required `type` and every
@@ -683,8 +683,8 @@ provider-wide fields plus fields belonging to the matching selected kinds. Field
 kind are not exposed through that service integration slot.
 
 Define `integrations[].env` when the service should own the final runtime names or add service-specific literal values.
-In this mode, `env` is the complete output mapping: raw provider variables are not injected automatically. Reference a
-declared input with `{{integration.variables.NAME}}`:
+In this mode, `env` is the complete set of environment variables Wodby injects for the integration: raw provider
+variables are not injected automatically. Reference a declared input with `{{integration.variables.NAME}}`:
 
 ```yaml
 integrations:
@@ -709,22 +709,22 @@ integrations:
         value: "{{integration.variables.BILLING_ACCOUNT_ID}}"
 ```
 
-Generic environment mappings follow these rules:
+Service-defined integration environment variables follow these rules:
 
 - They are supported only for `type: variable`, require `variables`, and cannot be combined with `multiple: true` or
   `providers`.
 - They can reference only variables declared by the same integration requirement. Provider field tokens are not
   available.
-- A secret input can be mapped only to an environment variable with `secret: true`.
+- A secret input can be injected only into an environment variable with `secret: true`.
 - An optional variable token must be the complete `value`. Wodby omits that environment variable when the selected
   integration does not supply the optional input; embedding an optional token in a larger string is invalid.
 - Literal values are allowed. Every output is runtime-only and is never passed to an image build.
 
-The mapping lets a service depend on a stable provider input shape while retaining control of the application-facing
+This lets a service depend on a stable provider input shape while retaining control of the application-facing
 environment names. Existing service manifests without `env` keep the direct-export behavior.
 
 Do not combine `variables` with `providers`. A native variable contract consumes provider environment variables by
-their declared names, while `providers` defines provider-specific projections to different environment variables.
+their declared names, while `providers` defines provider-specific environment variables.
 
 Each `integrations[].providers[]` item supports:
 

--- a/2.0/docs/services/template.md
+++ b/2.0/docs/services/template.md
@@ -182,8 +182,8 @@ actions:
 
 ### Environment variable object
 
-Used by `env`, `workloads[].containers[].env`, `links[].env`, `integrations[].providers[].env`, `imports[].init.env`, and
-`derivatives[].env`.
+Used by `env`, `workloads[].containers[].env`, `links[].env`, `integrations[].env`,
+`integrations[].providers[].env`, `imports[].init.env`, and `derivatives[].env`.
 
 - `name`: required environment variable name.
 - `value`: required string value.
@@ -214,7 +214,7 @@ runtime, Wodby includes variables without `envType` and variables matching the a
 Environment-variable names must follow the
 [platform naming and reserved-name rules](../apps/environment-variables.md#names-and-reserved-variables).
 
-Provider-specific integration env vars under `integrations[].providers[].env` are runtime-only. They must remain
+Integration env vars under `integrations[].env` and `integrations[].providers[].env` are runtime-only. They must remain
 runtime-enabled and cannot use `build: true`.
 
 ### Helm value object
@@ -639,6 +639,7 @@ Each item supports:
 - `multiple`: optional boolean.
 - `labels`: optional labels used to filter compatible provider kinds.
 - `variables`: optional environment-variable contract for a variable integration.
+- `env`: optional provider-independent output mapping for a variable integration.
 - `providers`: optional provider-specific overrides.
 
 An attached integration is compatible only when one of its selected provider kinds has the required `type` and every
@@ -675,10 +676,52 @@ creates its own [custom variable provider](../providers/variable.md#custom-varia
 uses `labels`, Wodby verifies during import that a current public or organization provider kind satisfies the complete
 contract.
 
-When `variables` is present, Wodby injects only the variables declared by the service. Deployment fails if a required
-value is missing, resolves more than once, or is not stored with the declared secret classification. Without
-`variables`, the existing behavior remains: Wodby injects provider-wide fields plus fields belonging to the matching
-selected kinds. Fields belonging only to another selected kind are not exposed through that service integration slot.
+When `variables` is present without `env`, Wodby injects only the variables declared by the service, using their
+provider variable names. Deployment fails if a required value is missing, resolves more than once, or is not stored
+with the declared secret classification. Without `variables`, the existing behavior remains: Wodby injects
+provider-wide fields plus fields belonging to the matching selected kinds. Fields belonging only to another selected
+kind are not exposed through that service integration slot.
+
+Define `integrations[].env` when the service should own the final runtime names or add service-specific literal values.
+In this mode, `env` is the complete output mapping: raw provider variables are not injected automatically. Reference a
+declared input with `{{integration.variables.NAME}}`:
+
+```yaml
+integrations:
+  - name: billing
+    title: Billing API
+    type: variable
+    variables:
+      - name: BILLING_API_URL
+      - name: BILLING_API_TOKEN
+        secret: true
+      - name: BILLING_ACCOUNT_ID
+        optional: true
+    env:
+      - name: APP_BILLING_DRIVER
+        value: external
+      - name: APP_BILLING_ENDPOINT
+        value: "{{integration.variables.BILLING_API_URL}}"
+      - name: APP_BILLING_TOKEN
+        value: "{{integration.variables.BILLING_API_TOKEN}}"
+        secret: true
+      - name: APP_BILLING_ACCOUNT
+        value: "{{integration.variables.BILLING_ACCOUNT_ID}}"
+```
+
+Generic environment mappings follow these rules:
+
+- They are supported only for `type: variable`, require `variables`, and cannot be combined with `multiple: true` or
+  `providers`.
+- They can reference only variables declared by the same integration requirement. Provider field tokens are not
+  available.
+- A secret input can be mapped only to an environment variable with `secret: true`.
+- An optional variable token must be the complete `value`. Wodby omits that environment variable when the selected
+  integration does not supply the optional input; embedding an optional token in a larger string is invalid.
+- Literal values are allowed. Every output is runtime-only and is never passed to an image build.
+
+The mapping lets a service depend on a stable provider input shape while retaining control of the application-facing
+environment names. Existing service manifests without `env` keep the direct-export behavior.
 
 Do not combine `variables` with `providers`. A native variable contract consumes provider environment variables by
 their declared names, while `providers` defines provider-specific projections to different environment variables.


### PR DESCRIPTION
## Summary

- document provider-independent variable integration input contracts and service-defined runtime environment variables
- add complete `integrations[].env` syntax, validation rules, secret handling, optional-value behavior, and backwards compatibility
- clarify when Wodby injects provider variables directly and when it injects only the variables defined by the service

## Validation

- `mkdocs build -f 2.0/mkdocs.yml -d /tmp/wodby-docs-integration-env-vars-site`
- checked changed public content and PR metadata for private repository or resource references

## Availability

Publish this documentation with or after the platform release that supports service-defined integration environment variables.