### PR TITLE
Document integration provider revision updates

### DIFF
--- a/2.0/docs/integrations/index.md
+++ b/2.0/docs/integrations/index.md
@@ -59,6 +59,14 @@ added kind. Some resource-creation permissions cannot be proven without changing
 reported as unverifiable rather than treated as an update failure. For AWS, GCP, and Azure, you can rerun the permission
 test from the integration's **Edit** page.
 
+## Provider revisions and updates
+
+Provider changes create new revisions. When an integration remains on the provider revision it was configured against,
+it is marked **Outdated** if a newer revision is available. Compatible integrations can be updated explicitly from
+their detail page; incompatible integrations remain pinned and show why a migration is required.
+
+See [Integration provider updates](updates.md) for the update workflow and compatibility rules.
+
 ## Where integrations are used
 
 Depending on the provider and type, integrations can be used for:
@@ -78,5 +86,6 @@ Depending on the provider and type, integrations can be used for:
 - [Provider vs integration](providers-vs-integrations.md)
 - [Providers overview](../providers/index.md)
 - [Integration types](types.md)
+- [Integration provider updates](updates.md)
 - [Share an OAuth integration with another organization](organization-sharing.md)
 - [Variable integration](variable.md)

--- a/2.0/docs/integrations/updates.md
+++ b/2.0/docs/integrations/updates.md
@@ -1,0 +1,85 @@
+# Integration provider updates
+
+Providers can change after you create an integration. Wodby publishes each provider change as a new revision. A
+compatible managed-provider rollout can advance integrations automatically; otherwise, an existing integration stays
+on the revision it was configured against. Revision pinning prevents an incompatible provider update from silently
+changing how existing credentials, selected kinds, or environment variables are interpreted.
+
+New integrations use the provider's current revision. Existing integrations continue working with their pinned
+revision until you update them explicitly.
+
+For a custom provider, including a Git-backed provider, manual and automatic provider updates publish a new revision
+without changing existing integrations.
+
+## Find outdated integrations
+
+An integration is **Outdated** when its pinned provider revision is older than the provider's current revision. The
+dashboard shows an **Outdated** label in the `Integrations` list.
+
+Open the integration to compare its current and target provider revisions. Users with `Modify/Delete` access can also
+see whether Wodby can update the integration safely.
+
+An outdated integration is not automatically broken or disabled. It continues using its pinned provider revision.
+
+## Update an integration
+
+To update an integration:
+
+1. Open `Integrations` and select an integration marked **Outdated**.
+2. Review the current and target revisions in the provider update notice.
+3. Review any compatibility reasons shown by Wodby.
+4. If the update is compatible, select `Update provider`.
+
+Wodby checks compatibility again when you submit the update. A successful update changes the integration's provider
+revision and related selected-kind metadata together.
+
+When a provider update leaves existing integrations pinned, update each compatible integration when you are ready to
+adopt the new contract.
+
+## Compatible updates
+
+The `Update provider` action is available only when the integration's stored configuration is compatible with the
+current provider revision. Wodby evaluates the actual integration, including:
+
+- selected kinds and kind options
+- authentication and scope
+- stored fields and their environment-variable mappings
+- field types and secret storage
+- required fields and validation rules
+- provider version compatibility, when the provider uses semantic versions
+
+Additive changes do not necessarily block an update. For example, adding a new kind that the integration does not use
+or adding an optional field can remain compatible.
+
+## Updates that require migration
+
+When Wodby cannot preserve the existing integration contract safely, the integration stays pinned and the dashboard
+shows the compatibility reasons instead of the update action. Examples include:
+
+- removing a selected kind or required capability
+- removing a field for which the integration has a stored value
+- adding a required field without a stored value
+- changing a field's environment-variable name, type, or secret classification
+- changing authentication or scope in a way that does not match the integration
+- adding validation that rejects the stored value
+- moving to an incompatible major provider version
+
+The provider's new revision remains available to new integrations. Existing incompatible integrations require a
+provider-specific migration or a replacement integration before they can leave the older revision.
+
+## Shared OAuth integrations
+
+An OAuth integration shared with another organization has one canonical source integration and one or more receiving
+organization handles. The source owner controls provider revision updates. Wodby updates the source and all handles as
+one operation so they cannot interpret the shared credentials using different provider revisions.
+
+A receiving organization can see that its handle is outdated, but it cannot initiate the update. Ask the source
+organization owner to update the canonical integration.
+
+## Related pages
+
+- [Integrations overview](index.md)
+- [Provider vs integration](providers-vs-integrations.md)
+- [Organization sharing](organization-sharing.md)
+- [Providers overview](../providers/index.md)
+- [Custom variable providers](../providers/custom-variable-providers.md)

--- a/2.0/docs/providers/custom-variable-providers.md
+++ b/2.0/docs/providers/custom-variable-providers.md
@@ -174,13 +174,17 @@ connection, so changing them from one resource also changes them for the other r
 ### Revision and compatibility rules
 
 - Keep the manifest `name` unchanged.
-- If integrations already use the provider, an update must preserve the credential contract: kind names and options,
-  field names and types, environment-variable mappings, validation, optionality, and upload constraints.
-- Metadata-only changes, such as titles, instructions, and icons, can update existing integrations to the new provider
-  revision automatically.
+- Every valid content change creates a new provider revision, including credential-contract changes.
+- New integrations use the current provider revision.
+- Existing integrations remain pinned to the revision they were configured against and are marked **Outdated** when a
+  newer revision exists.
+- Compatible integrations can be updated explicitly from the integration detail page.
+- Incompatible integrations continue using their pinned revision until a migration or replacement path is available.
 
-Make a credential-contract change before creating integrations, or create a separate provider contract and move
-integrations deliberately.
+Before updating an integration, Wodby checks its selected kinds, authentication, scope, stored fields, environment
+variables, secret storage, and validation against the current provider revision. Removing a stored field, adding a
+required field without a value, or changing a field's type or variable mapping can require migration. See
+[Integration provider updates](../integrations/updates.md) for the full workflow.
 
 ## Automatic updates from Git
 
@@ -191,9 +195,9 @@ Git-backed providers can update when a supported Git integration receives a matc
 - commit-pinned sources cannot use automatic updates
 
 Configure this under `Operations > Git auto update settings`. Tag matching applies to Git refs and is independent of
-the provider manifest revision. Automatic updates use the same manifest validation and compatibility rules as manual
-updates. A rejected update leaves the current provider revision active; open the provider's `Tasks` tab to review the
-error.
+the provider manifest revision. Automatic updates use the same manifest validation rules as manual updates. A valid
+change publishes a new provider revision and leaves existing integrations pinned. A rejected manifest update leaves the
+current provider revision active; open the provider's `Tasks` tab to review the error.
 
 ## Sharing and deletion
 
@@ -208,6 +212,7 @@ disconnect a repository that is still used by another provider, service, or stac
 
 - [Variable providers](variable.md)
 - [Variable integrations](../integrations/variable.md)
+- [Integration provider updates](../integrations/updates.md)
 - [Provider vs integration](../integrations/providers-vs-integrations.md)
 - [Git providers](git.md)
 - [Sharing](../sharing.md)

--- a/2.0/docs/providers/index.md
+++ b/2.0/docs/providers/index.md
@@ -9,6 +9,10 @@ Providers are Wodby's definitions for supported third-party services. A provider
 
 When you create a new integration, you first choose the provider and then fill in the fields required by that provider.
 
+Provider changes are published as new revisions. New integrations use the current revision. Existing integrations can
+be advanced by a compatible managed rollout or remain pinned until they are
+[updated explicitly](../integrations/updates.md).
+
 If you are choosing by task rather than by vendor, start with [Integration types](../integrations/types.md) and then jump to the matching provider group from there.
 
 ## How provider pages are organized
@@ -49,4 +53,5 @@ manifest, Git layout, update, task, and sharing workflows.
 - [Integrations overview](../integrations/index.md)
 - [Integration types](../integrations/types.md)
 - [Variable integration](../integrations/variable.md)
+- [Integration provider updates](../integrations/updates.md)
 - [Custom variable providers](custom-variable-providers.md)

--- a/2.0/mkdocs.yml
+++ b/2.0/mkdocs.yml
@@ -275,6 +275,7 @@ nav:
       - Derivatives: services/derivatives.md
   - Integrations:
       - Overview: integrations/index.md
+      - Updates: integrations/updates.md
       - Types: integrations/types.md
       - Organization sharing: integrations/organization-sharing.md
       - Variable integrations: integrations/variable.md


### PR DESCRIPTION
Provider revisions can leave integrations on an older contract, but the documentation does not explain the Outdated state or how users can adopt a compatible revision. The custom-provider guide also describes the previous behavior that rejected credential-contract changes. This update documents revision pinning, compatibility checks, and the explicit integration update workflow.

Summary:
- add an Integration provider updates page and navigation entry
- explain the Outdated indicator and Update provider action
- document compatible and migration-required changes
- explain source-owner control for shared OAuth integrations
- update custom Git-backed provider behavior for manual and automatic revisions
- link the workflow from the integration and provider overviews

Validation:
- mkdocs build --strict
- public-content and metadata scan for private repository names, links, and internal references

Publication:
- keep this pull request as draft until the integration provider revision update controls are available in the product
- no separate documentation migration is required