### PR TITLE
Document deployment readiness and queueing

### DIFF
--- a/2.0/docs/apps/builds.md
+++ b/2.0/docs/apps/builds.md
@@ -43,6 +43,15 @@ is not selected keeps its current deployment, or remains undeployed, until its o
 Linked image targets are part of their source owner's build; they are not separate source owners and do not add another
 build requirement to the group.
 
+When a source owner is selected for a new build, every selected linked image target or derivative that consumes its
+artifact follows the new output. Wodby does not combine that new owner build with an older image selection for one of
+its consumers in the same deployment.
+
+A previous successful build can still be selected as the image for another service. That reused image records what
+will run, but Wodby does not wait for it again or count it as the result of a selected new source-owner build. If a
+required new build fails or finishes without reporting its expected output, Wodby cancels the deployment that was
+waiting for it; deployments that only reuse an already successful image from that build are unaffected.
+
 Build image targets without their own build source are optional. If a build does not produce an image for one of those services, Wodby deploys the service with the configured image from the service manifest or chart. This lets pipelines build `nginx` only when the app needs custom static assets, while still allowing `nginx` to deploy normally as part of the stack.
 
 ## Build info

--- a/2.0/docs/apps/deploys.md
+++ b/2.0/docs/apps/deploys.md
@@ -19,6 +19,25 @@ Deployments are usually triggered in the following ways:
 - automated partial deployments for service-level maintenance
 - manual deployment from the UI
 
+## Deployment readiness and queueing
+
+`Awaiting` and `Queued` describe different stages of a deployment:
+
+- `Awaiting` means Wodby cannot create the deployment task yet. For example, one or more selected new builds have not
+  supplied deployable images, or the target cluster is undergoing an infrastructure upgrade.
+- `Queued` means the deployment has everything it needs and its task is waiting for the app instance's current
+  deployment or post-deployment operation to finish.
+
+Wodby runs one app-service deployment or post-deployment operation at a time for each app instance. If several
+deployments are requested, each keeps its own service and build selections and joins that instance's task queue when it
+becomes ready. Builds can finish in a different order from the requests, so deployments are queued in readiness order,
+not necessarily deployment-number order.
+
+Wodby does not discard a deployment merely because another deployment or a higher-numbered build exists. Selecting an
+older build can be an intentional rollback, and one multi-service deployment can intentionally combine older and newer
+builds. If a pending request is no longer wanted, cancel that deployment or its task explicitly; starting another
+deployment does not replace it.
+
 ## First deployment
 
 App creation does not always pre-create a full deployment that waits for every buildable service. Initial behavior
@@ -35,10 +54,13 @@ depends on the enabled services and who starts their builds:
   deploy when their own CI builds report back or when they are included in a later explicit operation.
 
 When an app has not yet established its runtime, a build-backed deployment also includes all enabled services without
-build sources if any of them has not deployed successfully, is unhealthy, or needs redeployment. This is an initial
-runtime safety rule, not an inferred companion relationship between independent build-source owners. Optional build
-image targets without their own source can use the image produced by their linked owner or their configured service
-image when that build does not provide one.
+build sources while any of those services has never deployed successfully. This is an initial runtime safety rule, not
+an inferred companion relationship between independent build-source owners. After that bootstrap, a partial
+deployment includes an unrelated service without a build source only when it is marked `needs redeploy` and is not
+already covered by another active deployment. An unhealthy status by itself does not expand a deployment.
+
+Optional build image targets without their own source can use the image produced by their linked owner or their
+configured service image when that build does not provide one.
 
 A partial deployment can complete successfully while the app instance remains `awaiting`. The instance becomes `ok`
 only after every enabled service that requires a Wodby-managed runtime has a usable deployment. Services omitted from
@@ -140,6 +162,11 @@ When you select **New build** for multiple source owners, Wodby creates one awai
 builds together. That deployment waits for exactly the selected owners. Selecting only one source owner does not wait
 for other buildable services in the app; a full new-build deployment includes every build-source owner and waits for
 all of them.
+
+When a selected source owner uses **New build**, selected linked image targets and derivatives that consume its output
+follow that same new build. Wodby does not keep an older image selection for one of those consumers inside the same
+deployment. A previous successful build selected for another service is treated only as a reusable image: it does not
+satisfy a selected **New build**, keep the deployment waiting, or make that deployment depend on another CI run.
 
 If you deploy only a subset of services, Wodby applies that ordering only inside the selected set. Repository
 post-deployment scripts run only when the app service that owns the corresponding build is included in the selected

--- a/2.0/docs/cicd/deploy.md
+++ b/2.0/docs/cicd/deploy.md
@@ -18,7 +18,12 @@ A post-deployment failure does not change the successful deployment or app statu
 Deployment details show a separate post-deployment warning and task log. You can retry only the failed
 post-deployment task without redeploying the application.
 
-`wodby ci deploy` queues the deployment and returns without waiting for the rollout or post-deployment task. Operational
-CLI commands that stream deployment logs or explicitly wait for a deployment follow both tasks and return a non-zero
-exit code when the post-deployment task fails. The error identifies that the rollout completed successfully and the
-failure came from post-deployment scripts.
+`wodby ci deploy` records the released build as deployable and returns without waiting for the rollout or
+post-deployment task. The deployment can remain `Awaiting` while other selected builds finish or the cluster completes
+infrastructure maintenance. When all inputs are ready, its normal deployment task becomes `Queued` behind any current
+deployment or post-deployment operation for that app instance. See
+[Deployment readiness and queueing](../apps/deploys.md#deployment-readiness-and-queueing).
+
+Operational CLI commands that stream deployment logs or explicitly wait for a deployment follow both tasks and return
+a non-zero exit code when the post-deployment task fails. The error identifies that the rollout completed successfully
+and the failure came from post-deployment scripts.


### PR DESCRIPTION
The public deployment guide did not clearly distinguish a deployment that is still waiting for builds from one that is ready and queued, or explain whether a newer request replaces an older one. This update documents both stages and makes clear that each requested service/build selection is preserved until it runs or is explicitly canceled.

It also documents:
- per-instance serialization of deployment and post-deployment operations
- readiness-order queueing when builds finish out of request order
- propagation of a new source-owner build to selected linked targets and derivatives
- reused builds as image selections rather than new build requirements
- failure isolation between required new builds and reused successful images
- first-deployment bootstrap companions versus later services marked needs redeploy
- the asynchronous wodby ci deploy transition from Awaiting to Queued

Validation:
- mkdocs build -d /private/tmp/wodby-docs-deployment-lifecycle-site
- git diff --check

Publish this documentation with the Wodby 2 task-backed deployment queue behavior.